### PR TITLE
Allow posting a model with single related model

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -890,10 +890,18 @@ class API(ModelView):
             # Handling relations, a single level is allowed
             for col in set(relations).intersection(paramkeys):
                 submodel = cols[col].property.mapper.class_
-                for subparams in params[col]:
-                    kw = unicode_keys_to_strings(subparams)
+                
+                if type(params[col]) == type([]):
+                    # model has several related objects
+                    for subparams in params[col]:
+                        kw = unicode_keys_to_strings(subparams)
+                        subinst = _get_or_create(self.session, submodel, **kw)[0]
+                        getattr(instance, col).append(subinst)
+                else:
+                    # model has single related object
+                    kw = unicode_keys_to_strings(params[col])
                     subinst = _get_or_create(self.session, submodel, **kw)[0]
-                    getattr(instance, col).append(subinst)
+                    setattr(instance, col, subinst)
 
             # add the created model to the session
             self.session.add(instance)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -117,6 +117,7 @@ class TestSupport(FlaskTestBase):
             vendor = Column(Unicode)
             buy_date = Column(DateTime)
             owner_id = Column(Integer, ForeignKey('person.id'))
+            owner = relationship('Person')
 
         class Person(self.Base):
             __tablename__ = 'person'
@@ -125,8 +126,7 @@ class TestSupport(FlaskTestBase):
             age = Column(Float)
             other = Column(Float)
             birth_date = Column(Date)
-            computers = relationship('Computer',
-                                     backref=backref('owner', lazy='dynamic'))
+            computers = relationship('Computer')
 
         class Planet(self.Base):
             __tablename__ = 'planet'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -300,6 +300,18 @@ class APITestCase(TestSupport):
 
         response = self.app.get('/api/person')
         self.assertEqual(len(loads(response.data)['objects']), 1)
+        
+    def test_post_with_single_submodel(self):
+        response = self.app.post('/api/computer', data=dumps({
+                                                   'vendor': u'Apple', 
+                                                   'name': u'iMac', 
+                                                   'owner': {'name': u'John', 'age': 2041}
+                                                   }))
+        self.assertEqual(response.status_code, 201)
+        self.assertIn('id', loads(response.data))
+        # Test if owner was successfully created
+        response = self.app.get('/api/person')
+        self.assertEqual(len(loads(response.data)['objects']), 1)
 
     def test_delete(self):
         """Test for deleting an instance of the database using the


### PR DESCRIPTION
I.e. when relation is many-to-one or one-to-one (model being posted belongs-to or has a related object).

Current implementation expects to get a list of related objects.
