### PR TITLE
Added 'total_pages' to paginated requests

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -22,6 +22,7 @@
 
 """
 import datetime
+import math
 
 from dateutil.parser import parse as parse_datetime
 from flask import abort
@@ -756,13 +757,17 @@ class API(ModelView):
             page_num = int(request.args.get('page', 1))
             start = (page_num - 1) * self.results_per_page
             end = min(len(instances), start + self.results_per_page)
+            total_pages = int(math.ceil(len(instances) / float(self.results_per_page)))
+
         else:
             page_num = 1
             start = 0
             end = len(instances)
+            total_pages = 1
+            
         objects = [_to_dict_include(x, deep, include=self.include_columns)
                    for x in instances[start:end]]
-        return jsonify(page=page_num, objects=objects)
+        return jsonify(page=page_num, objects=objects, total_pages=total_pages)
 
     def _check_authentication(self):
         """If the specified HTTP method requires authentication (see the

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -805,37 +805,48 @@ class APITestCase(TestSupport):
             d = dict(name=unicode('person%s' % i))
             response = self.app.post('/api/person', data=dumps(d))
             self.assertEqual(response.status_code, 201)
+
         response = self.app.get('/api/person')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(loads(response.data)['page'], 1)
         self.assertEqual(len(loads(response.data)['objects']), 10)
+        self.assertEqual(loads(response.data)['total_pages'], 3)
+
         response = self.app.get('/api/person?page=1')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(loads(response.data)['page'], 1)
         self.assertEqual(len(loads(response.data)['objects']), 10)
+        self.assertEqual(loads(response.data)['total_pages'], 3)
+
         response = self.app.get('/api/person?page=2')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(loads(response.data)['page'], 2)
         self.assertEqual(len(loads(response.data)['objects']), 10)
+        self.assertEqual(loads(response.data)['total_pages'], 3)
+
         response = self.app.get('/api/person?page=3')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(loads(response.data)['page'], 3)
         self.assertEqual(len(loads(response.data)['objects']), 5)
+        self.assertEqual(loads(response.data)['total_pages'], 3)
 
         response = self.app.get('/api/v2/person?page=3')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(loads(response.data)['page'], 3)
         self.assertEqual(len(loads(response.data)['objects']), 5)
+        self.assertEqual(loads(response.data)['total_pages'], 5)
 
         response = self.app.get('/api/v3/person')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(loads(response.data)['page'], 1)
         self.assertEqual(len(loads(response.data)['objects']), 25)
+        self.assertEqual(loads(response.data)['total_pages'], 1)
 
         response = self.app.get('/api/v3/person?page=2')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(loads(response.data)['page'], 1)
         self.assertEqual(len(loads(response.data)['objects']), 25)
+        self.assertEqual(loads(response.data)['total_pages'], 1)
 
     def test_alternate_primary_key(self):
         """Tests that models with primary keys which are not ``id`` columns are


### PR DESCRIPTION
This adds a total_pages field to every paginated JSON response.

I think this is necessary in order to set up pagination controllers in the client UI.
Tests added
