### PR TITLE
fixbug zero prefix id as integer when primary key type is string

### DIFF
--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -376,10 +376,8 @@ class APIManager(object):
                                view_func=api_view)
         # the per-instance endpoints will allow both integer and string primary
         # key accesses
-        for converter in ('int', 'string'):
-            instance_endpoint = '%s/<%s:instid>' % (collection_endpoint,
-                                                    converter)
-            blueprint.add_url_rule(instance_endpoint, methods=instance_methods,
+        instance_endpoint = '%s/<instid>' % (collection_endpoint)
+        blueprint.add_url_rule(instance_endpoint, methods=instance_methods,
                                    view_func=api_view)
         # if function evaluation is allowed, add an endpoint at /api/eval/...
         # which responds only to GET requests and responds with the result of


### PR DESCRIPTION
the type of model primary key is string, I got 404 error when I get the url:
http://localhost:5000/api/bjlx/01. I found that string '01' convert to 1(int). so it could not found the object for database. 

```
class Bjlx(db.Model):
    bjlxdm = db.Column(db.String(2), primary_key=True)
    bjlxmc = db.Column(db.String(64), nullable=False)

```
