### PR TITLE
Return 404 if target id of put/patch request does not exist.

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1159,6 +1159,8 @@ class API(ModelView):
         else:
             # create a SQLAlchemy Query which has exactly the specified row
             query = self._query_by_primary_key(instid)
+            if query.count() == 0:
+                abort(404)
             assert query.count() == 1, 'Multiple rows with same ID'
 
         relations = self._update_relations(query, data)


### PR DESCRIPTION
Currently, a put/patch request to an invalid ID fails the assert on line 1164 in views.py.  We should handle this gracefully, so we abort with a 404.

A 404 error is in line with what is returned if a GET request is issued for an invalid id.
