### PR TITLE
validation exception handler: also catch ValueError when splitting

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -753,8 +753,8 @@ class API(ModelView):
         # 'message' comes from savalidation
         if hasattr(exception, 'message'):
             # TODO this works only if there is one validation error
-            left, right = exception.message.rsplit(':', 1)
             try:
+                left, right = exception.message.rsplit(':', 1)
                 left_bracket = left.rindex('[')
                 right_bracket = right.rindex(']')
             except ValueError:


### PR DESCRIPTION
Just a minor fix in case the exception's error message does not contain a colon :)
(e.g. sqlalchemy: "(IntegrityError) column uuid is not unique u'INSERT INTO [...]")

```
File "[...}/site-packages/flask_restless/views.py", line 702, in _extract_error_messages
    left, right = exception.message.rsplit(':', 1)
ValueError: need more than 1 value to unpack
```

HTH :cake: 
