### PR TITLE
Should use custom query classes on model objects

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -43,3 +43,10 @@ def unicode_keys_to_strings(dictionary):
 
     """
     return dict((str(k), v) for k, v in dictionary.iteritems())
+
+
+def session_query(session, model):
+    if hasattr(model, 'query'):
+        return model.query
+    else:
+        return session.query(model)

--- a/flask_restless/search.py
+++ b/flask_restless/search.py
@@ -16,6 +16,7 @@
 import inspect
 
 from .helpers import unicode_keys_to_strings
+from .helpers import session_query
 
 #: The mapping from operator name (as accepted by the search method) to a
 #: function which returns the SQLAlchemy expression corresponding to that
@@ -353,10 +354,7 @@ class QueryBuilder(object):
 
         """
         # Adding field filters
-        if hasattr(model, 'query'):
-            query = model.query
-        else:
-            query = session.query(model)
+        query = session_query(session, model)
         # may raise exception here
         filters = QueryBuilder._create_filters(model, search_params)
         for filt in filters:

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -49,6 +49,7 @@ from sqlalchemy.sql import func
 
 from .helpers import partition
 from .helpers import unicode_keys_to_strings
+from .helpers import session_query
 from .search import create_query
 from .search import search
 
@@ -117,10 +118,7 @@ def _get_or_create(session, model, **kwargs):
     :func:`sqlalchemy.orm.query.Query.filter_by` function.
 
     """
-    if hasattr(model, 'query'):
-        query = model.query
-    else:
-        query = session.query(model)
+    query = session_query(session, model)
     instance = query.filter_by(**kwargs).first()
     if instance:
         return instance, False
@@ -434,10 +432,7 @@ class ModelView(MethodView):
 
         """
         the_model = model or self.model
-        if hasattr(the_model, 'query'):
-            return the_model.query
-        else:
-            return self.session.query(the_model)
+        return session_query(self.session, the_model)
 
 
 class FunctionAPI(ModelView):


### PR DESCRIPTION
tl;dr: This is a simple one-line change that does nothing except allowing flask-restless to use any custom query classes defined on an model. 

There are many use cases where it is desirable to automatically add a few custom query parameters to all SQLAlchemy queries for that class. Perhaps the best example is if you want to limit all queries to `Model.deleted==False`, but this can also be used for authorization, by limiting with something like `Model.owner==current_user.get_id()`. 

This automatic filtering can be done by defining a `query_class` class attribute on a model, or by defining a `query` property on the model. [An example of the latter pattern is here.](http://stackoverflow.com/questions/920724/the-right-way-to-auto-filter-sqlalchemy-queries) In both cases the query class that is attached to the model class should inherit from `sqlalchemy.orm.query.Query`, or, when using flask-sqlalchemy, from `flask_sqlalchemy.BaseQuery`.  

For whatever reason, SQLAlchemy's `session.query(model)` bypasses this query class attached to the model. But if flask-restless instead builds the query starting from `model.query`, it _will_ use this custom query class. 

Both the query returned by `session.query(model)` and the one returned by `model.query` are attached to the same session object, as you can verify by looking at the query's `.session` attribute. So it is unlikely that this change will cause any problems with session handling. 

If a model doesn't have a custom `query_property` or a `query` attribute defined, then this change does nothing: both `model.query` and `session.query(model)` return the same object in that case.

I am by no means an expert in the wild and mysterious world of SQLAlchemy query and session handling, but I have dug through the relevant code a bit and I believe this change is ok. If there's something wrong with it I would very much like to know what.
