### PR TITLE
views._get_or_create() should not commit()

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -150,7 +150,7 @@ def _get_or_create(session, model, **kwargs):
         return instance, False
     instance = model(**kwargs)
     session.add(instance)
-    session.commit()
+    session.flush()
     return instance, True
 
 


### PR DESCRIPTION
`views._get_or_create()` is called by `views.API._add_to_relation()`, and `_add_to_relation()` explicitly states that it does not call commit.

This causes a bug when you are creating a new row and associating it with a relation that is a many-to-many relation. After this call to `commit()`, the query object in `_add_to_relation()` will (sometimes) return an empty list. After that, even though the dependent object/row has been created, it will not be appended to the main object relation(s), because the `for instance in query` is now iterating over an empty list. Changing this `commit` to `flush` fixes the problem.

As noted, this only happens sometimes, it seems to be dependent on the preceding sequence of calls to `session.commit()`.
