### PR TITLE
use any version of python-dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask>=0.7
 flask-sqlalchemy
 sqlalchemy
-python-dateutil<2.0
+python-dateutil
 simplejson

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 #: The installation requirements for Flask-Restless. ``simplejson`` is only
 #: required on Python version 2.5. ``Flask-SQLAlchemy`` is not required, so the
 #: user must install it explicitly.
-requirements = ['flask>=0.7', 'sqlalchemy', 'python-dateutil<2.0']
+requirements = ['flask>=0.7', 'sqlalchemy', 'python-dateutil']
 if sys.version_info < (2, 6):
     requirements.append('simplejson')
 


### PR DESCRIPTION
I've been running flask-restless with python-dateutil 2.1 in my project since I started, and I even have a test showing that timezone conversion is working correctly.

The only use of python-dateutil is the `dateutil.parse()` call and that doesn't appear to have changed between 1.5 and 2.1. It seems the major difference between 1.5 and 2.1 is that 2.1 is compatible with Python 3.
