### PR TITLE
AssociationProxy fields don't have a property value

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -50,6 +50,7 @@ from sqlalchemy.orm.properties import RelationshipProperty as RelProperty
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql import func
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.associationproxy import AssociationProxy
 
 from .helpers import partition
 from .helpers import unicode_keys_to_strings
@@ -116,7 +117,10 @@ def _is_date_field(model, fieldname):
     :class:`datetime.datetime` object.
 
     """
-    prop = getattr(model, fieldname).property
+    field = getattr(model, fieldname)
+    if isinstance(field, AssociationProxy):
+        field = field.remote_attr
+    prop = field.property
     if isinstance(prop, RelationshipProperty):
         return False
     fieldtype = prop.columns[0].type


### PR DESCRIPTION
If you are using `sqlalchemy.ext.associationproxy.association_proxy` for any of your columns, then flask-restless will crash when trying to save. It is checking the properties on fields in the model to find out of they are date/datetime fields, but `AssociationProxy` fields don't have `property` attributes, so that code just crashes:

```
File "flask_restless/views.py", line 1381, in put
  return self.patch(instid)
File "flask_restless/views.py", line 1346, in patch
  data = self._strings_to_dates(data)
File "flask_restless/views.py", line 880, in _strings_to_dates
  if _is_date_field(self.model, fieldname) and value is not None:
File "flask_restless/views.py", line 119, in _is_date_field
  prop = getattr(model, fieldname).property
```

This patch changes it to pass through to the real field on the remote table when an `AssociationProxy` is encountered, so that field can be checked for whether or not this is a date value.
