### PR TITLE
Fall back on unittest if unittest2 is not installed

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -5,11 +5,14 @@ import os.path
 import sys
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
-import unittest2
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 from tests import suite
 
 def main():
-    unittest2.main(defaultTest='suite')
+    unittest.main(defaultTest='suite')
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,10 @@ if sys.version_info < (2, 6):
 else:
     requirements.append('python-dateutil!=2.0')
 
+test_requirements = []
+if sys.version_info < (2, 7):
+    test_requirements.append('unittest2')
+
 
 class run_coverage(Command):
     """Runs ``coverage``, the Python code coverage tool to generate a test
@@ -102,7 +106,7 @@ setup(
     platforms='any',
     packages=['flask_restless'],
     test_suite='tests.suite',
-    tests_require=['unittest2'],
+    tests_require=test_requirements,
     url='http://github.com/jfinkels/flask-restless',
     version='0.9.4-dev',
     zip_safe=False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,8 +25,10 @@
     :license: GNU AGPLv3+ or BSD
 
 """
-from unittest2 import TestSuite
-from unittest2 import defaultTestLoader
+try:
+    from unittest2 import TestSuite, defaultTestLoader
+except ImportError:
+    from unittest import TestSuite, defaultTestLoader
 
 from . import test_helpers
 from . import test_manager

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -18,8 +18,11 @@
     :license: GNU AGPLv3+ or BSD
 
 """
-import unittest2
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from . import suite
 
-unittest2.main(defaultTest='suite')
+unittest.main(defaultTest='suite')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,10 @@
 
 """
 import datetime
-from unittest2 import TestCase
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
 
 from flask import Flask
 from sqlalchemy import Column

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,8 +8,10 @@
     :license: GNU AGPLv3+ or BSD
 
 """
-from unittest2 import TestCase
-from unittest2 import TestSuite
+try:
+    from unittest2 import TestCase, TestSuite
+except ImportError:
+    from unittest import TestCase, TestSuite
 
 from flask.ext.restless.helpers import partition
 from flask.ext.restless.helpers import unicode_keys_to_strings

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -9,8 +9,10 @@
 
 """
 import datetime
-from unittest2 import skipUnless
-from unittest2 import TestSuite
+try:
+    from unittest2 import TestSuite, skipUnless
+except ImportError:
+    from unittest import TestSuite, skipUnless
 
 from flask import json
 try:

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -12,7 +12,10 @@
 from __future__ import with_statement
 
 from datetime import date
-from unittest2 import TestSuite
+try:
+    from unittest2 import TestSuite
+except ImportError:
+    from unittest import TestSuite
 
 from flask import json
 from flask.ext.restless.views import ProcessingException

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,7 +10,10 @@
 """
 from __future__ import with_statement
 
-from unittest2 import TestSuite
+try:
+    from unittest2 import TestSuite
+except ImportError:
+    from unittest import TestSuite
 
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.orm.exc import NoResultFound

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,8 +20,10 @@ from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import Unicode
 from sqlalchemy.orm import validates
-from unittest2 import TestSuite
-from unittest2 import skipUnless
+try:
+    from unittest2 import TestSuite, skipUnless
+except ImportError:
+    from unittest import TestSuite, skipUnless
 
 # for SAValidation package on pypi.python.org
 try:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -13,8 +13,10 @@ from __future__ import with_statement
 
 from datetime import date
 from datetime import datetime
-from unittest2 import TestSuite
-from unittest2 import skipUnless
+try:
+    from unittest2 import TestSuite, skipUnless
+except ImportError:
+    from unittest import TestSuite, skipUnless
 
 from flask import json
 try:


### PR DESCRIPTION
The `unittest2` module is available as `unittest` on Python 2.7 and later. For those versions, installing `unittest2` should not be required.
