### PR TITLE
check all parent classes for hybrid properties

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -190,12 +190,14 @@ def _to_dict(instance, deep=None):
     related instances.
 
     """
-    # create an iterable of names of columns, including hybrid properties
-    columns = itertools.chain(
-        (p.key for p in object_mapper(instance).iterate_properties
-            if isinstance(p, ColumnProperty)),
-        (key for key, value in instance.__class__.__dict__.iteritems()
-            if isinstance(value, hybrid_property)))
+    # create a list of names of columns, including hybrid properties
+    columns = [p.key for p in object_mapper(instance).iterate_properties
+            if isinstance(p, ColumnProperty)]
+    for parent in type(instance).mro():
+        columns.extend(
+            [key for key,value in parent.__dict__.iteritems()
+            if isinstance(value, hybrid_property)]
+        )
     # create a dictionary mapping column name to value
     result = dict((col, getattr(instance, col)) for col in columns)
     # Convert datetime and date objects to ISO 8601 format.


### PR DESCRIPTION
In order to find all hybrid properties, the code must look through all base classes. This is because the object of type `hybrid_property` is only visible in the `__dict__` of the base class where it was defined, and not in derived classes. Without this, if you have a `hybrid_property` defined in a base class (perhaps one containing several common columns and a property calculation that you'll need on more than one table) then this code wouldn't find that `hybrid_property` to show it in the API.

For more on `hybrid_property`, see also pull request #138.
