### PR TITLE
Return all fields of the object when posting, nost just the id

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -915,7 +915,15 @@ class API(ModelView):
         """
         return self._query_by_primary_key(primary_key_value, model).first()
 
-    def _inst_to_dict(self, instid):
+    def _inst_to_dict(self, inst):
+        """Returns the dictionary representation of the specified instance.
+        """
+        # create a placeholder for the relations of the returned models
+        relations = frozenset(get_relations(self.model))
+        deep = dict((r, {}) for r in relations)
+        return _to_dict(inst, deep)
+
+    def _instid_to_dict(self, instid):
         """Returns the dictionary representation of the instance specified by
         `instid`.
 
@@ -926,10 +934,7 @@ class API(ModelView):
         inst = self._get_by(instid)
         if inst is None:
             abort(404)
-        # create a placeholder for the relations of the returned models
-        relations = frozenset(get_relations(self.model))
-        deep = dict((r, {}) for r in relations)
-        return _to_dict(inst, deep)
+        return self._inst_to_dict(inst)
 
     def get(self, instid):
         """Returns a JSON representation of an instance of model with the
@@ -950,7 +955,7 @@ class API(ModelView):
                 return self._search()
             for preprocessor in self.preprocessors['GET_SINGLE']:
                 preprocessor(instid)
-            result = self._inst_to_dict(instid)
+            result = self._instid_to_dict(instid)
             for postprocessor in self.postprocessors['GET_SINGLE']:
                 result = postprocessor(result)
             return jsonpify(result)
@@ -1069,10 +1074,7 @@ class API(ModelView):
             # add the created model to the session
             self.session.add(instance)
             self.session.commit()
-
-            pk_name = str(_primary_key_name(instance))
-            pk_value = getattr(instance, pk_name)
-            result = {pk_name: pk_value}
+            result = self._inst_to_dict(instance)
 
             try:
                 for postprocessor in self.postprocessors['POST']:
@@ -1080,7 +1082,6 @@ class API(ModelView):
             except ProcessingException, e:
                 return jsonify_status_code(status_code=e.status_code,
                                            message=e.message)
-
             return jsonify_status_code(201, **result)
         except self.validation_exceptions, exception:
             return self._handle_validation_exception(exception)
@@ -1181,7 +1182,7 @@ class API(ModelView):
                 return jsonify_status_code(status_code=e.status_code,
                                            message=e.message)
         else:
-            result = self._inst_to_dict(instid)
+            result = self._instid_to_dict(instid)
             try:
                 for postprocessor in self.postprocessors['PATCH_SINGLE']:
                     result = postprocessor(result)


### PR DESCRIPTION
I'm using restless as the backend for a grid widget (http://demos.kendoui.com/web/grid/index.html) with built-in crud functionality. Restless is a perfect fit for the task except that when you create new items, the Kendo Grid requires all fields of the object to be returned so that it is able to sync itself with the data. In case the database did truncate something or other kind of data massaging. I'd imagine it could be useful to other REST consumers too. The small patch below makes it happen. :)
