### PR TITLE
PATCH method should also catch IntegrityError

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1170,6 +1170,8 @@ class API(ModelView):
             self.session.commit()
         except self.validation_exceptions, exception:
             return self._handle_validation_exception(exception)
+        except IntegrityError, error:
+            return jsonify_status_code(400, message=error.message)
 
         # Perform any necessary postprocessing.
         if patchmany:


### PR DESCRIPTION
Patch method doesnt catch IntegrityError which I think is an oversight because POST does. So here it is added.
