### PR TITLE
API to control how relationships are serialized

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -190,6 +190,10 @@ def _to_dict(instance, deep=None):
     :func:`!_to_dict` returns a list of the string representations of the
     related instances.
 
+    Note that the relations specified in `deep` are only traversed if
+    they have already been loaded by sqlalchemy. This gives the user a
+    chance to customize how "deep" objects are serialized.
+
     """
     # create an iterable of names of columns, including hybrid properties
     columns = itertools.chain(
@@ -205,9 +209,15 @@ def _to_dict(instance, deep=None):
     for key, value in result.items():
         if isinstance(value, datetime.date):
             result[key] = value.isoformat()
-    # recursively call _to_dict on each of the `deep` relations
-    deep = deep or {}
-    for relation, rdeep in deep.iteritems():
+
+    # Recursively call _to_dict on each of the `deep` relations after
+    # it has been filtered. We do not want to load any relations that
+    # sqlalchemys normal relationship loading feature would load.
+    loaded_rels = instance.__dict__
+    deep = (deep or {}).iteritems()
+    deep = ((rel, rdeep) for (rel, rdeep) in deep if rel in loaded_rels)
+
+    for relation, rdeep in deep:
         # Get the related value so we can see if it is None, a list, a query
         # (as specified by a dynamic relationship loader), or an actual
         # instance of a model.


### PR DESCRIPTION
Currently flask-restless follows all relationships downwards and upwards when serializing models to json. It can be pretty bad for performance because it can result in hundreds of queries to return a single object. My proposed "simple" solution is to only serialize already loaded relationships, but skip those that require database lookups. E.g:

```
class User(db.Model):
    scores = db.relationship('Score', lazy = 'dynamic')
```

This would not fetch all scores because `lazy='dynamic'` means the relatoinship isn't loaded.

```
class User(db.Model):    
    scores = db.relationship('Score', lazy = 'joined')
```

But this would because `joined` means sqlalchemy preloads the score rows.

A real API for controlling traversal would be nice, but some control is better than nothing. :) Please ignore all commits in the pr expect for (https://github.com/bjourne/flask-restless/commit/6bebdd7e785c3ae6f4aa22ce00e57354e715860e), i wasn't able to isolate it cleanly.
