### PR TITLE
New preprocessor/postprocessor functions should permit return value that signifies no change to data

### DIFF
--- a/flask_restless/__init__.py
+++ b/flask_restless/__init__.py
@@ -20,4 +20,4 @@ __version__ = '0.10.0-dev'
 
 # make the following names available as part of the public API
 from .manager import APIManager
-from .views import ProcessingException
+from .views import ProcessingException, NO_CHANGE

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -81,6 +81,7 @@ class ProcessingException(Exception):
         self.message = message
         self.status_code = status_code
 
+NO_CHANGE = object()
 
 def jsonify_status_code(status_code, *args, **kw):
     """Returns a jsonified response with the specified HTTP status code.
@@ -817,7 +818,9 @@ class API(ModelView):
 
         # exceptions are caught by the get() method, which calls this one
         for preprocessor in self.preprocessors['GET_MANY']:
-            data = preprocessor(data)
+            new_data = preprocessor(data)
+            if new_data is not NO_CHANGE:
+                data = new_data
 
         # perform a filtered search
         try:
@@ -841,7 +844,9 @@ class API(ModelView):
             result = _to_dict(result, deep)
 
         for postprocessor in self.postprocessors['GET_MANY']:
-            result = postprocessor(result)
+            new_result = postprocessor(result)
+            if new_result is not NO_CHANGE:
+                result = new_result
 
         return jsonpify(result)
 
@@ -963,7 +968,9 @@ class API(ModelView):
                 preprocessor(instid)
             result = self._instid_to_dict(instid)
             for postprocessor in self.postprocessors['GET_SINGLE']:
-                result = postprocessor(result)
+                new_result = postprocessor(result)
+                if new_result is not NO_CHANGE:
+                    result = new_result
             return jsonpify(result)
         except ProcessingException, e:
             return jsonify_status_code(status_code=e.status_code,
@@ -1029,7 +1036,9 @@ class API(ModelView):
         # apply any preprocessors to the POST arguments
         try:
             for preprocessor in self.preprocessors['POST']:
-                params = preprocessor(params)
+                new_params = preprocessor(params)
+                if new_params is not NO_CHANGE:
+                    params = new_params
         except ProcessingException, e:
             return jsonify_status_code(status_code=e.status_code,
                                        message=e.message)
@@ -1084,7 +1093,9 @@ class API(ModelView):
 
             try:
                 for postprocessor in self.postprocessors['POST']:
-                    result = postprocessor(result)
+                    new_result = postprocessor(result)
+                    if new_result is not NO_CHANGE:
+                        result = new_result
             except ProcessingException, e:
                 return jsonify_status_code(status_code=e.status_code,
                                            message=e.message)
@@ -1125,14 +1136,18 @@ class API(ModelView):
                 # dictionary indicate a change in the model's field.
                 search_params = data.pop('q', {})
                 for preprocessor in self.preprocessors['PATCH_MANY']:
-                    search_params, data = preprocessor(search_params, data)
+                    result = preprocessor(search_params, data)
+                    if result is not NO_CHANGE:
+                        search_params, data = result
             except ProcessingException, e:
                 return jsonify_status_code(status_code=e.status_code,
                                            message=e.message)
         else:
             try:
                 for preprocessor in self.preprocessors['PATCH_SINGLE']:
-                    data = preprocessor(instid, data)
+                    new_data = preprocessor(instid, data)
+                    if new_data is not NO_CHANGE:
+                        data = new_data
             except ProcessingException, e:
                 return jsonify_status_code(status_code=e.status_code,
                                            message=e.message)
@@ -1185,7 +1200,9 @@ class API(ModelView):
             result = dict(num_modified=num_modified)
             try:
                 for postprocessor in self.postprocessors['PATCH_MANY']:
-                    result = postprocessor(query, result)
+                    new_result = postprocessor(query, result)
+                    if new_result is not NO_CHANGE:
+                        result = new_result
             except ProcessingException, e:
                 return jsonify_status_code(status_code=e.status_code,
                                            message=e.message)
@@ -1193,7 +1210,9 @@ class API(ModelView):
             result = self._instid_to_dict(instid)
             try:
                 for postprocessor in self.postprocessors['PATCH_SINGLE']:
-                    result = postprocessor(result)
+                    new_result = postprocessor(result)
+                    if new_result is not NO_CHANGE:
+                        result = new_result
             except ProcessingException, e:
                 return jsonify_status_code(status_code=e.status_code,
                                            message=e.message)


### PR DESCRIPTION
I am testing out the latest changes to Flask-Restless so I can support association proxies in SQLAlchemy. However, the removal of the authentication function and switch to preprocessor functions is kind of frustrating.

I would like to have a single function that will enforce authentication for all of my API requests for GET, POST, PATCH, and DELETE. However, using the new preprocessor functions I have to return different values for each processor type. This makes it difficult to have just a single function for all of these HTTP methods since the processors are required to return different values.

For instance I will need to have different authentication functions for PATCH (single) and POST. The PATCH (single) function has to return the second argument to the function to be able to just show that nothing has changed, while the POST function has to return the first argument to show that nothing has changed. So basically I need 6 different authentication methods for each pre-processor type now instead of 1 and none of them are doing anything to the data.

I think the best fix for this would be that if any of the pre/post-processor functions return None (or maybe some other sentinel/special value) it would not alter the data at all. This would allow me to have a single authentication processor function that could be used for all HTTP methods.
