### PR TITLE
Association proxy fails if the remote attribute is a column and not a relationship

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -94,5 +94,8 @@ def get_related_model(model, relationname):
     if relationname in cols and isinstance(attr.property, RelProperty):
         return cols[relationname].property.mapper.class_
     elif isinstance(attr, AssociationProxy):
-        return attr.remote_attr.property.mapper.class_
+        if hasattr(attr.remote_attr.property, 'mapper'):
+            return attr.remote_attr.property.mapper.class_
+        elif hasattr(attr.remote_attr.property, 'parent'):
+            return attr.remote_attr.property.parent.class_
     return None

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -26,6 +26,7 @@ else:
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
+from sqlalchemy import Table
 from sqlalchemy import Unicode
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.associationproxy import association_proxy as prox
@@ -1389,6 +1390,14 @@ class AssociationProxyTest(DatabaseTestBase):
         """
         super(AssociationProxyTest, self).setUp()
 
+        tag_product = Table('tag_product', self.Base.metadata,
+                            Column('tag_id', Integer,
+                                   ForeignKey('tag.id'),
+                                   primary_key=True),
+                            Column('product_id', Integer,
+                                   ForeignKey('product.id'),
+                                   primary_key=True))
+
         class Image(self.Base):
             __tablename__ = 'image'
             id = Column(Integer, primary_key=True)
@@ -1405,6 +1414,12 @@ class AssociationProxyTest(DatabaseTestBase):
             image = rel('Image', backref=backref(name='chosen_product_images',
                                                  cascade="all, delete-orphan"),
                         enable_typechecks=False)
+            name = Column(Unicode, default=lambda: "default name")
+
+        class Tag(self.Base):
+            __tablename__ = 'tag'
+            id = Column(Integer, primary_key=True)
+            name = Column(Unicode, nullable=False)
 
         class Product(self.Base):
             __tablename__ = 'product'
@@ -1415,10 +1430,16 @@ class AssociationProxyTest(DatabaseTestBase):
             chosen_images = prox('chosen_product_images', 'image',
                                  creator=lambda image:
                                      ChosenProductImage(image=image))
+            image_names = prox('chosen_product_images', 'name')
+            tags = rel(Tag, secondary=tag_product,
+                       backref=backref(name='products', lazy='dynamic'))
+            tag_names = prox('tags', 'name',
+                             creator=lambda tag_name: Tag(name=tag_name))
 
         self.Product = Product
         self.Image = Image
         self.ChosenProductImage = ChosenProductImage
+        self.Tag = Tag
 
         # create all the tables required for the models
         self.Base.metadata.create_all()
@@ -1460,8 +1481,10 @@ class AssociationProxyTest(DatabaseTestBase):
         self.assertIn('chosen_images', data)
         self.assertEquals(data['chosen_images'], [{'id': 1}, {'id': 2}])
         self.assertEquals(data['chosen_product_images'],
-                          [{'image_id': 1, 'product_id': 1},
-                           {'image_id': 2, 'product_id': 1}])
+                          [{'image_id': 1, 'product_id': 1,
+                            'name': 'default name'},
+                           {'image_id': 2, 'product_id': 1,
+                            'name': 'default name'}])
 
         response = self.app.get('/api/image/1')
         data = loads(response.data)
@@ -1615,6 +1638,24 @@ class AssociationProxyTest(DatabaseTestBase):
         self.assertEqual(response.status_code, 200)
         data = loads(response.data)
         self.assertEqual(data['num_results'], 0)
+
+    def test_association_proxy_scalar(self):
+        """Tests that association proxies to remote scalar attributes work
+        correctly.
+
+        This is also somewhat tested indirectly through the
+        other tests here for the chosen product image names but this is
+        a direct test with the Tags and a different type of relation
+        """
+        self.session.add(self.Product())
+        self.session.commit()
+
+        data = {'tag_names': ['tag1', 'tag2']}
+        response = self.app.patch('/api/product/1', data=dumps(data))
+        self.assertEqual(response.status_code, 200)
+        data = loads(response.data)
+
+        self.assertEqual(sorted(data['tag_names']), sorted(['tag1', 'tag2']))
 
 
 def load_tests(loader, standard_tests, pattern):


### PR DESCRIPTION
I have an association proxy with the remote attribute as a unicode value. With the lastest changes on master I cannot get any object from the API that has a proxy like this. I get an exception like:

```
...snip...
File "/home/bpedersen/git/flask-restless/flask_restless/views.py", line 948, in _instid_to_dict
    return self._inst_to_dict(inst)
File "/home/bpedersen/git/flask-restless/flask_restless/views.py", line 935, in _inst_to_dict
    return _to_dict(inst, deep)
File "/home/bpedersen/git/flask-restless/flask_restless/views.py", line 229, in _to_dict
    result[relation] = [_to_dict(inst, rdeep) for inst in relatedvalue]
File "/home/bpedersen/git/flask-restless/flask_restless/views.py", line 195, in _to_dict
    columns = [p.key for p in object_mapper(instance).iterate_properties
File "/home/bpedersen/virtualenv/restless/lib/python2.7/site-packages/sqlalchemy/orm/util.py", line 1084, in object_mapper
    return object_state(instance).mapper
File "/home/bpedersen/virtualenv/restless/lib/python2.7/site-packages/sqlalchemy/orm/util.py", line 1106, in object_state
    raise exc.UnmappedInstanceError(instance)
UnmappedInstanceError: Class '__builtin__.unicode' is not mapped
```

This is easily reproducible in the tests by adding this column on the `ChosenProductImage` class to create a random number (could also create a random string to see the exact message I get):

```
name = Column(Integer, default=lambda: random.randint(1, 1000))
```

and then add the following to the `Product` class:

```
image_numbers = prox('chosen_product_images', 'name')
```
