### PR TITLE
Correct HTTP codes for query errors

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -50,6 +50,7 @@ from sqlalchemy.orm.query import Query
 from sqlalchemy.sql import func
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.associationproxy import AssociationProxy
+from sqlalchemy.sql.expression import _BinaryExpression
 
 from .helpers import get_columns
 from .helpers import get_related_model
@@ -110,6 +111,16 @@ def jsonpify(*args, **kw):
         mimetype = 'application/javascript'
         return current_app.response_class(content, mimetype=mimetype)
     return response
+
+
+# TODO: On SQLAlchemy 0.8, this should use the new inspection API
+def _has_field(model, fieldname):
+    """Returns ``True`` if the `model` has the specified field, and it is not
+    a hybrid property.
+
+    """
+    return (hasattr(model, fieldname) and
+            not isinstance(getattr(model, fieldname), _BinaryExpression))
 
 
 def _is_date_field(model, fieldname):
@@ -1060,7 +1071,7 @@ class API(ModelView):
         # Check for any request parameter naming a column which does not exist
         # on the current model.
         for field in params:
-            if not hasattr(self.model, field):
+            if not _has_field(self.model, field):
                 msg = "Model does not have field '%s'" % field
                 return jsonify_status_code(400, message=msg)
 
@@ -1168,7 +1179,7 @@ class API(ModelView):
         # Check for any request parameter naming a column which does not exist
         # on the current model.
         for field in data:
-            if not hasattr(self.model, field):
+            if not _has_field(self.model, field):
                 msg = "Model does not have field '%s'" % field
                 return jsonify_status_code(400, message=msg)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -474,6 +474,9 @@ class APITestCase(TestSupport):
         response = self.app.post('/api/person', data=dumps(dict(bogus=0)))
         self.assertEqual(400, response.status_code)
 
+        response = self.app.post('/api/person', data=dumps(dict(is_minor=True)))
+        self.assertEqual(400, response.status_code)
+
     def test_post_nullable_date(self):
         """Tests the creation of a model with a nullable date field."""
         self.manager.create_api(self.Star, methods=['GET', 'POST'])


### PR DESCRIPTION
Respond with HTTP 400 for queries with multiple or no results, as
specified in the documentation
