### PR TITLE
Correct HTTP codes for query errors

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -823,9 +823,9 @@ class API(ModelView):
         try:
             result = search(self.session, self.model, data)
         except NoResultFound:
-            return jsonify(message='No result found')
+            return jsonify_status_code(400, message='No result found')
         except MultipleResultsFound:
-            return jsonify(message='Multiple results found')
+            return jsonify_status_code(400, message='Multiple results found')
         except:
             return jsonify_status_code(400,
                                        message='Unable to construct query')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -957,7 +957,7 @@ class APITestCase(TestSupport):
         # Looking for something that does not exist on the database
         search['filters'][0]['val'] = 'Sammy'
         resp = self.app.search('/api/person', dumps(search))
-        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 400)
         self.assertEqual(loads(resp.data)['message'], 'No result found')
 
         # We have to receive an error if the user provides an invalid
@@ -1061,7 +1061,7 @@ class APITestCase(TestSupport):
 
         # Testing multiple results when calling .one()
         resp = self.app.search('/api/person', dumps({'single': True}))
-        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 400)
         self.assertEqual(loads(resp.data)['message'], 'Multiple results found')
 
     def test_search_bad_arguments(self):


### PR DESCRIPTION
Respond with HTTP 400 for queries with multiple or no results, as
specified in the documentation
