### PR TITLE
Fix primary key identification

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -28,6 +28,7 @@ import itertools
 import datetime
 import math
 import warnings
+import inspect
 
 from dateutil.parser import parse as parse_datetime
 from flask import abort
@@ -40,10 +41,10 @@ from sqlalchemy import Date
 from sqlalchemy import DateTime
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import ColumnProperty
 from sqlalchemy.orm import object_mapper
 from sqlalchemy.orm import RelationshipProperty
+from sqlalchemy.orm.attributes import QueryableAttribute
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.query import Query
@@ -177,9 +178,13 @@ def _primary_key_name(model_or_instance):
 
     """
     its_a_model = isinstance(model_or_instance, type)
-    mapper = class_mapper if its_a_model else object_mapper
-    mapped = mapper(model_or_instance)
-    primary_key_names = [key.name for key in mapped.primary_key]
+    model = model_or_instance if its_a_model else model_or_instance.__class__
+
+    primary_key_names = [key for key, field in inspect.getmembers(model)
+                         if isinstance(field, QueryableAttribute)
+                         and isinstance(field.property, ColumnProperty)
+                         and field.property.columns[0].primary_key]
+
     return 'id' if 'id' in primary_key_names else primary_key_names[0]
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -136,7 +136,7 @@ class TestSupport(DatabaseTestBase):
 
         class Star(self.Base):
             __tablename__ = 'star'
-            id = Column(Integer, primary_key=True)
+            id = Column("star_id", Integer, primary_key=True)
             inception_time = Column(DateTime, nullable=True)
 
         self.Person = Person

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -41,6 +41,7 @@ from flask.ext.restless.manager import APIManager
 from flask.ext.restless.views import _evaluate_functions as evaluate_functions
 from flask.ext.restless.views import _get_or_create
 from flask.ext.restless.views import _to_dict
+from flask.ext.restless.views import _primary_key_name
 
 from .helpers import DatabaseTestBase
 from .helpers import FlaskTestBase
@@ -210,6 +211,15 @@ class ModelTestCase(TestSupport):
         self.assertEqual(me_dict['name'], u'Lincoln')
         self.assertEqual(me_dict['age'], 24)
         self.assertEqual(me_dict['birth_date'], me.birth_date.isoformat())
+
+    def test_primary_key_name(self):
+        """Test for determining the primary attribute of a model or instance.
+
+        """
+        me = self.Person(name=u'Lincoln', age=24, birth_date=date(1986, 9, 15))
+        self.assertEqual('id', _primary_key_name(me))
+        self.assertEqual('id', _primary_key_name(self.Person))
+        self.assertEqual('id', _primary_key_name(self.Star))
 
     def test_to_dict_dynamic_relation(self):
         """Tests that a dynamically queried relation is resolved when getting


### PR DESCRIPTION
_primary_key_name was finding the table column name, however it should
find the attribute name of the model
