### PR TITLE
Add hybrid_properties to list of columns from helper

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -171,7 +171,8 @@ class ModelHelpersTest(TestSupport):
         columns = get_columns(self.Person)
         self.assertEqual(sorted(columns.keys()), sorted(['age', 'birth_date',
                                                          'computers', 'id',
-                                                         'name', 'other']))
+                                                         'is_minor', 'name',
+                                                         'other']))
 
     def test_get_relations(self):
         """Tests getting the names of the relations of a model as strings."""


### PR DESCRIPTION
When performing a post to create a new instance we were not allowing the user to
set values for a hybrid_property since it was not in the set of defined columns.
However, a patch/put request worked just fine to update the attribute. This
change fixes it so you can set the hybrid_property attribute during a post
request.
