### PR TITLE
Improve has/any search. Fixes jfinkels/flask-restless#180

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -129,11 +129,15 @@ def get_related_model(model, relationname):
     if relationname in cols and isinstance(attr.property, RelProperty):
         return cols[relationname].property.mapper.class_
     elif isinstance(attr, AssociationProxy):
-        if hasattr(attr.remote_attr.property, 'mapper'):
-            return attr.remote_attr.property.mapper.class_
-        elif hasattr(attr.remote_attr.property, 'parent'):
-            return attr.remote_attr.property.parent.class_
+        return get_related_association_proxy_model(attr)
     return None
+
+
+def get_related_association_proxy_model(attr):
+    if hasattr(attr.remote_attr.property, 'mapper'):
+        return attr.remote_attr.property.mapper.class_
+    elif hasattr(attr.remote_attr.property, 'parent'):
+        return attr.remote_attr.property.parent.class_
 
 
 def has_field(model, fieldname):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -185,6 +185,85 @@ class TestOperators(TestSupportPrefilled):
         result = search(self.session, self.Computer, d)
         assert len(result) == 3
 
+    def test_has_and_any_suboperators(self):
+        """Tests for the ``"has"`` and ``"any"`` operators with suboperators.
+
+        The `any` operator returns all instances for which any related instance
+        in a given collection has some property. The `has` operator returns all
+        instances for which a related instance has a given property.
+
+        """
+        # create test computers
+        computer1 = self.Computer(name=u'c1', vendor=u'foo')
+        computer2 = self.Computer(name=u'c2', vendor=u'bar')
+        computer3 = self.Computer(name=u'c3', vendor=u'bar')
+        computer4 = self.Computer(name=u'c4', vendor=u'bar')
+        computer5 = self.Computer(name=u'c5', vendor=u'foo')
+        computer6 = self.Computer(name=u'c6', vendor=u'foo')
+        self.session.add_all((computer1, computer2, computer3, computer4,
+                                 computer5, computer6))
+        self.session.commit()
+        # add the computers to three test people
+        person1, person2, person3 = self.people[:3]
+        person1.computers = [computer1, computer2, computer3]
+        person2.computers = [computer4]
+        person3.computers = [computer5, computer6]
+        self.session.commit()
+        # test 'any'
+        d = dict(filters=[dict(name='computers', op='any',
+                               val=dict(name='vendor', op='like', val=u'%o%'),
+                               )])
+        result = search(self.session, self.Person, d)
+        assert len(result) == 2
+        # test 'has'
+        d = dict(filters=[dict(name='owner', op='has',
+                               val=dict(name='name', op='like', val=u'%incol%'),
+                               )])
+        result = search(self.session, self.Computer, d)
+        assert len(result) == 3
+
+
+    def test_has_and_any_nested_suboperators(self):
+        """Tests for the ``"has"`` and ``"any"`` operators with nested suboperators.
+
+        The `any` operator returns all instances for which any related instance
+        in a given collection has some property. The `has` operator returns all
+        instances for which a related instance has a given property.
+
+        """
+        # create test computers
+        computer1 = self.Computer(name=u'c1', vendor=u'foo')
+        computer2 = self.Computer(name=u'c2', vendor=u'bar')
+        computer3 = self.Computer(name=u'c3', vendor=u'bar')
+        computer4 = self.Computer(name=u'c4', vendor=u'bar')
+        computer5 = self.Computer(name=u'c5', vendor=u'foo')
+        computer6 = self.Computer(name=u'c6', vendor=u'foo')
+        self.session.add_all((computer1, computer2, computer3, computer4,
+                                 computer5, computer6))
+        self.session.commit()
+        # add the computers to three test people
+        person1, person2, person3 = self.people[:3]
+        person1.computers = [computer1, computer2, computer3]
+        person2.computers = [computer4]
+        person3.computers = [computer5, computer6]
+        self.session.commit()
+        # test 'any'
+        d = dict(filters=[dict(name='computers', op='any',
+                               val=dict(name='owner', op='has',
+                                        val=dict(name='name', op='like', val=u'%incol%')
+                                        ),
+                               )])
+        result = search(self.session, self.Person, d)
+        assert len(result) == 1
+        # test 'has'
+        d = dict(filters=[dict(name='owner', op='has',
+                               val=dict(name='computers', op='any',
+                                        val=dict(name='vendor', op='like', val='%o%')
+                                        ),
+                               )])
+        result = search(self.session, self.Computer, d)
+        assert len(result) == 5
+
 
 class TestSearch(TestSupportPrefilled):
     """Unit tests for the :func:`flask_restless.search.search` function.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1626,6 +1626,15 @@ class TestAssociationProxy(DatabaseTestBase):
         data = loads(response.data)
         assert data['num_results'] == 0
 
+        filters = {'filters':
+                       [{'name': 'chosen_images', 'op': 'any', 'val': {'name':'id', 'op':'eq', 'val':1}}]}
+        response = self.app.get('/api/product?q=' + dumps(filters))
+        assert response.status_code == 200
+        data = loads(response.data)
+        assert data['num_results'] == 0
+
+
+
     def test_scalar(self):
         """Tests that association proxies to remote scalar attributes work
         correctly.


### PR DESCRIPTION
This patch improves the `has` and `any` operators as described in jfinkels/flask-restless#180. We have been using it for a while and it works well.
