### PR TITLE
Firefox append Content-type header with "charset=UTF-8" 

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -976,7 +976,7 @@ class API(ModelView):
 
         """
         content_type = request.headers.get('Content-Type', None)
-        if content_type.count('application/json'):
+        if not content_type.count('application/json'):
             msg = 'Request must have "Content-Type: application/json" header'
             return jsonify_status_code(415, message=msg)
 
@@ -1076,7 +1076,7 @@ class API(ModelView):
 
         """
         content_type = request.headers.get('Content-Type', None)
-        if content_type.count('application/json'):
+        if not content_type.count('application/json'):
             msg = 'Request must have "Content-Type: application/json" header'
             return jsonify_status_code(415, message=msg)
 


### PR DESCRIPTION
Firefox has a known bug https://bugzilla.mozilla.org/show_bug.cgi?id=416178

And instead of "Content-Type: application/json" we get "Content-Type: application/json;charset=UTF-8"
