### PR TITLE
Allow  `application/json; charset=UTF-8` content-type. handle firefox bug #416178

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -987,7 +987,7 @@ class API(ModelView):
 
         """
         content_type = request.headers.get('Content-Type', None)
-        if content_type != 'application/json':
+        if not content_type.startswith('application/json'):
             msg = 'Request must have "Content-Type: application/json" header'
             return jsonify_status_code(415, message=msg)
 
@@ -1087,7 +1087,7 @@ class API(ModelView):
 
         """
         content_type = request.headers.get('Content-Type', None)
-        if content_type != 'application/json':
+        if not content_type.startswith('application/json'):
             msg = 'Request must have "Content-Type: application/json" header'
             return jsonify_status_code(415, message=msg)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1251,6 +1251,10 @@ class TestHeaders(TestSupportPrefilled):
         response = self.app.patch('/api/person/6', data=dumps(dict(name='x')),
                                   content_type='application/json')
         assert 200 == response.status_code
+        response = self.app.patch('/api/person/6', data=dumps(dict(name='x')),
+                                  content_type='application/json; charset=UTF-8')
+        assert 200 == response.status_code
+
         # A request without an Accept header should return JSON.
         assert 'Content-Type' in response.headers
         assert 'application/json' == response.headers['Content-Type']


### PR DESCRIPTION
Allow  `Content-Type:   application/json; charset=UTF-8` Headers.
https://bugzilla.mozilla.org/show_bug.cgi?id=416178
