### PR TITLE
Missing exceptions module error causing Flask-Restless to break

### DIFF
--- a/flask_restless/exceptions.py
+++ b/flask_restless/exceptions.py
@@ -9,7 +9,7 @@
 
 """
 from werkzeug.exceptions import default_exceptions, HTTPException
-from flask import abort
+from flask import abort, json
 from flask import make_response
 
 


### PR DESCRIPTION
The exceptions module was removed from the latest version of Flask
(0.9) and since it was added in the same version, it doesn't show up
in any earlier versions. This means that Flask-Restless is broken for
all versions of Flask. This commit adds the JSONHTTPResponse from the
removed exceptions module in Flask to the exceptions module in
Flask-Restless. The commit where the exceptions module was removed can
be seen here:
https://github.com/mitsuhiko/flask/commit/4c27f7a8c4bbe6621681178be716e6270067a3ad.
