### PR TITLE
Removing Python 2.5 from Travis config since Jinja2 no longer supports it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
   - "pypy"


### PR DESCRIPTION
The latest versions of Jinja2 no longer support Python 2.5 [[1](https://github.com/mitsuhiko/jinja2/pull/185#issuecomment-18098870), [2](https://github.com/mitsuhiko/jinja2/commit/b89d1a8fe3fcbd73a8f4cebd4358eadebc2d8a9d),
[3](https://github.com/mitsuhiko/jinja2/commit/8bdc65d9e57d5c0da329bb88127d977bd58002e5)]. Since Jinja2 is an integral part of Flask, this would also mean
that Flask no longer supports versions of Python prior to 2.6. Since
Flask no longer supports versions of Python prior to 2.6, plugins for
Flask do not need to support them either and so, the 2.5 Travis test
can be removed.
