### PR TITLE
Updated `__repr__` methods for several classes to work with Python 2.6 and above

### DIFF
--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -97,7 +97,7 @@ class APIManager(object):
     def _next_blueprint_name(self, basename):
         """Returns the next name for a blueprint with the specified base name.
 
-        This method returns a string of the form ``'{}{}'.format(basename,
+        This method returns a string of the form ``'{0}{1}'.format(basename,
         number)``, where ``number`` is the next non-negative integer not
         already used in the name of an existing blueprint.
 

--- a/flask_restless/search.py
+++ b/flask_restless/search.py
@@ -124,7 +124,7 @@ class OrderBy(object):
 
     def __repr__(self):
         """Returns a string representation of this object."""
-        return '<OrderBy {}, {}>'.format(self.field, self.direction)
+        return '<OrderBy {0}, {1}>'.format(self.field, self.direction)
 
 
 class Filter(object):
@@ -165,7 +165,7 @@ class Filter(object):
 
     def __repr__(self):
         """Returns a string representation of this object."""
-        return '<Filter {} {} {}>'.format(self.fieldname, self.operator,
+        return '<Filter {0} {1} {2}>'.format(self.fieldname, self.operator,
                                           self.argument or self.otherfield)
 
     @staticmethod
@@ -233,8 +233,8 @@ class SearchParameters(object):
 
     def __repr__(self):
         """Returns a string representation of the search parameters."""
-        template = ('<SearchParameters filters={}, order_by={}, limit={},'
-                    ' offset={}, junction={}>')
+        template = ('<SearchParameters filters={0}, order_by={1}, limit={2},'
+                    ' offset={3}, junction={4}>')
         return template.format(self.filters, self.order_by, self.limit,
                                self.offset, self.junction.__name__)
 


### PR DESCRIPTION
In a Python 2.6 repl an exception is thrown when viewing instances of
the Filter, SearchParameters, and OrderyBy classes. This is because
the call to `str.format` in the `__repr__` method of each omits the
indexes for the arguments, which is a feature added in Python 2.7.

From the Python docs [7.1.3. Format String Syntax](http://docs.python.org/2/library/string.html#format-string-syntax), "Changed in
version 2.7: The positional argument specifiers can be omitted, so '{}
{}' is equivalent to '{0} {1}'."

Also, the current code only works with Python 2.7+, this change gets 
the code to work with Python 2.6+, but if you want the code to work 
properly with Python 2.5+, you'll need to remove all calls to `str.format` 
completely since that method [was added in Python 2.6](http://docs.python.org/2/library/stdtypes.html#str.format).
