### PR TITLE
Removed a dependency on the Flask app from create_api_blueprint

### DIFF
--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -379,15 +379,13 @@ class APIManager(object):
                                validation_exceptions, results_per_page,
                                max_results_per_page, post_form_preprocessor,
                                preprocessors, postprocessors)
-        # suffix an integer to apiname according to already existing blueprints
-        blueprintname = self._next_blueprint_name(apiname)
         # add the URL rules to the blueprint: the first is for methods on the
         # collection only, the second is for methods which may or may not
         # specify an instance, the third is for methods which must specify an
         # instance
         # TODO what should the second argument here be?
         # TODO should the url_prefix be specified here or in register_blueprint
-        blueprint = Blueprint(blueprintname, __name__, url_prefix=url_prefix)
+        blueprint = Blueprint(apiname, __name__, url_prefix=url_prefix)
         # For example, /api/person.
         blueprint.add_url_rule(collection_endpoint,
                                methods=no_instance_methods, view_func=api_view)
@@ -448,4 +446,6 @@ class APIManager(object):
 
         """
         blueprint = self.create_api_blueprint(*args, **kw)
+        # suffix an integer to apiname according to already existing blueprints
+        blueprint.name = self._next_blueprint_name(blueprint.name)
         self.app.register_blueprint(blueprint)


### PR DESCRIPTION
The create_api_blueprint calls _next_blueprint_name which, in turn,
checks all blueprints on the Flask app object to see if any previously
registered blueprints have a matching name and, if so, it returns a
new name with a suffixed index. This creates a dependency on the app
object in the create_api_blueprint method. This can cause problems in
situations where the developer wishes to move the creation of the API
endpoints into a module separate from the one in which the app object
is created. Allowing the user to create blueprints for API endpoints
in a separate module without the need to import the app object is key
in preventing a circular dependency between modules.

Since creating an API blueprint is more of a "power user" function, it
stands to reason that making sure the name of the blueprint does not
overlap other registered blueprints should be a responsibility of the
developer. For this reason, I've moved the call to
_next_blueprint_name out of the create_api_blueprint method and into
the create_api method. In the latter case, things are a bit more
automated and the case for renaming blueprints is a little stronger
there.