### PR TITLE
support SQL-standard date/datetime functions

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -506,6 +506,8 @@ def strings_to_dates(model, dictionary):
         if is_date_field(model, fieldname) and value is not None:
             if value.strip() == '':
                 result[fieldname] = None
+            elif value in ('CURRENT_TIMESTAMP', 'CURRENT_DATE', 'LOCALTIMESTAMP',):
+                result[fieldname] = getattr(func, value.lower())()
             else:
                 result[fieldname] = parse_datetime(value)
         else:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,6 +10,8 @@
 
 """
 from datetime import date
+from datetime import datetime
+import dateutil
 
 from flask import json
 try:
@@ -384,6 +386,21 @@ class TestAPI(TestSupport):
         response = self.app.get('/api/star/1')
         assert response.status_code == 200
         assert loads(response.data)['inception_time'] is None
+
+    def test_post_date_functions(self):
+        """Tests that assigning an string like CURRENT_TIMESTAMP gets converted into a date."""
+        self.manager.create_api(self.Star, methods=['GET', 'POST'])
+        data = dict(inception_time='CURRENT_TIMESTAMP')
+        response = self.app.post('/api/star', data=dumps(data))
+        assert response.status_code == 201
+        response = self.app.get('/api/star/1')
+        assert response.status_code == 200
+        inception_time = loads(response.data)['inception_time']
+        assert inception_time is not None
+        inception_time = dateutil.parser.parse(inception_time)
+        diff = datetime.utcnow() - inception_time
+        assert diff.days == 0
+        assert (diff.seconds + diff.microseconds / 1000000.0) < 3600
 
     def test_post_with_submodels(self):
         """Tests the creation of a model with a related field."""


### PR DESCRIPTION
This allows setting date and datetime type fields to the values `CURRENT_DATE`, `CURRENT_TIMESTAMP`, and `LOCALTIMESTAMP` from the API, and translates that into SQL expressions that get evaluated by the database.

This allows client-side code to set a date or timestamp to current as seen by the server, in case the client computer's clock is incorrect.
