### PR TITLE
Add Exception removed in flask.

### DIFF
--- a/flask_restless/exceptions.py
+++ b/flask_restless/exceptions.py
@@ -8,10 +8,35 @@
     :license: GNU AGPLv3+ or BSD
 
 """
-from werkzeug.exceptions import default_exceptions
+from werkzeug.exceptions import default_exceptions, HTTPException
 from flask import abort
+from flask import json
 from flask import make_response
-from flask.exceptions import JSONHTTPException
+
+
+# Brought in from Flask after it was removed there in this commit:
+# 4c27f7a8c4bbe6621681178be716e6270067a3ad
+class JSONHTTPException(HTTPException):
+    """A base class for HTTP exceptions with ``Content-Type:
+    application/json``.
+
+    The ``description`` attribute of this class must set to a string (*not* an
+    HTML string) which describes the error.
+
+    """
+
+    def get_body(self, environ):
+        """Overrides :meth:`werkzeug.exceptions.HTTPException.get_body` to
+        return the description of this error in JSON format instead of HTML.
+        """
+        return json.dumps(dict(description=self.get_description(environ)))
+
+    def get_headers(self, environ):
+        """Returns a list of headers including ``Content-Type:
+        application/json``.
+
+        """
+        return [('Content-Type', 'application/json')]
 
 
 # Adapted from http://flask.pocoo.org/snippets/97


### PR DESCRIPTION
`JSONHTTPException` class (and in fact the entire module) was removed from Flask in this commit:

https://github.com/mitsuhiko/flask/commit/4c27f7a8c4bbe6621681178be716e6270067a3ad

There are some options that flask-restless has:
1. Reimplement the `JSONHTTPException` class so that it can be used in `json_abort`.
2. Change `json_abort` to not require the class.
3. Change places that use `json_abort(404)` to just use `abort(404)`.
4. Tie restless with version 0.9 of Flask.

Since the code base suggests we're only using `json_abort` for 404 messages I think that _probably_ the correct solution is 3. However, because I have no idea what other people are using restless for I have implemented 1 here for a more backwards-compatible, don't-rock-the-boat solution. 
