### PR TITLE
Explicit declaration of exposed sub-resources.

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -103,6 +103,15 @@ def upper_keys(d):
     return dict(zip((k.upper() for k in d.keys()), d.values()))
 
 
+def get_foreign_keys(model):
+    """Yields foreign keys defined in the model."""
+    for name, column in model.__table__.columns.items():
+        foreign_keys = list(column.foreign_keys)
+        if foreign_keys:
+            for key in foreign_keys:
+                yield (name, key)
+
+
 def get_columns(model):
     """Returns a dictionary-like object containing all the columns of the
     specified `model` class.
@@ -156,8 +165,7 @@ def get_related_association_proxy_model(attr):
 
 
 def has_field(model, fieldname):
-    """Returns ``True`` if the `model` has the specified field, and it is not
-    a hybrid property.
+    """Returns ``True`` if the `model` has the specified field.
 
     """
     return (hasattr(model, fieldname) and
@@ -325,6 +333,46 @@ def to_dict(instance, deep=None, exclude=None, include=None,
     # recursively call _to_dict on each of the `deep` relations
     deep = deep or {}
     for relation, rdeep in deep.iteritems():
+        # Skip relation if its included in exclude_columns
+        if exclude and relation in exclude:
+            continue
+
+        # Determine the included and excluded fields for the related model.
+        newexclude = None
+        newinclude = None
+
+        if exclude_relations is not None:
+            if relation in exclude_relations:
+                newexclude = exclude_relations[relation]
+            else:
+                # If the relation is not specifically excluded
+                # then we need to include it
+                newinclude = get_columns(
+                    type(getattr(instance, relation))).keys()
+        elif (include_relations is not None and
+              relation in include_relations):
+            newinclude = include_relations[relation]
+        elif exclude or exclude_relations:
+            # If the relation isn't excluded or included specifically
+            # we should include
+            newinclude = get_columns(type(getattr(instance, relation))).keys()
+
+
+        # Determine the included methods for the related model.
+        newmethods = None
+        if include_methods is not None:
+            newmethods = [method.split('.', 1)[1] for method in include_methods
+                        if method.split('.', 1)[0] == relation]
+
+        # If exclude or include is specified then we shouldn't be
+        # adding relation results if no relation include, exclude,
+        # or methods apply
+        if any(x is not None for x in (exclude, include, exclude_relations,
+                                       include_relations)) \
+                and all(x is None for x in (newexclude, newinclude,
+                                            newmethods)):
+            continue
+
         # Get the related value so we can see if it is None, a list, a query
         # (as specified by a dynamic relationship loader), or an actual
         # instance of a model.
@@ -332,25 +380,14 @@ def to_dict(instance, deep=None, exclude=None, include=None,
         if relatedvalue is None:
             result[relation] = None
             continue
-        # Determine the included and excluded fields for the related model.
-        newexclude = None
-        newinclude = None
-        if exclude_relations is not None and relation in exclude_relations:
-            newexclude = exclude_relations[relation]
-        elif (include_relations is not None and
-              relation in include_relations):
-            newinclude = include_relations[relation]
-        # Determine the included methods for the related model.
-        newmethods = None
-        if include_methods is not None:
-            newmethods = [method.split('.', 1)[1] for method in include_methods
-                        if method.split('.', 1)[0] == relation]
+
         if is_like_list(instance, relation):
             result[relation] = [to_dict(inst, rdeep, exclude=newexclude,
                                         include=newinclude,
                                         include_methods=newmethods)
                                 for inst in relatedvalue]
             continue
+
         # If the related value is dynamically loaded, resolve the query to get
         # the single instance.
         if isinstance(relatedvalue, Query):

--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -182,7 +182,8 @@ class APIManager(object):
                              include_methods=None, validation_exceptions=None,
                              results_per_page=10, max_results_per_page=100,
                              post_form_preprocessor=None,
-                             preprocessors=None, postprocessors=None):
+                             preprocessors=None, postprocessors=None,
+                             relationname=None):
         """Creates an returns a ReSTful API interface as a blueprint, but does
         not register it on any :class:`flask.Flask` application.
 
@@ -369,11 +370,13 @@ class APIManager(object):
             possibly_empty_instance_methods = methods & frozenset(('GET', ))
         instance_methods = \
             methods & frozenset(('GET', 'PATCH', 'DELETE', 'PUT'))
+
         # the base URL of the endpoints on which requests will be made
         collection_endpoint = '/%s' % collection_name
         # the name of the API, for use in creating the view and the blueprint
         apiname = APIManager.APINAME_FORMAT % collection_name
         # the view function for the API for this model
+
         api_view = API.as_view(apiname, self.session, model, exclude_columns,
                                include_columns, include_methods,
                                validation_exceptions, results_per_page,
@@ -385,48 +388,59 @@ class APIManager(object):
         # collection only, the second is for methods which may or may not
         # specify an instance, the third is for methods which must specify an
         # instance
+
         # TODO what should the second argument here be?
         # TODO should the url_prefix be specified here or in register_blueprint
         blueprint = Blueprint(blueprintname, __name__, url_prefix=url_prefix)
-        # For example, /api/person.
-        blueprint.add_url_rule(collection_endpoint,
-                               methods=no_instance_methods, view_func=api_view)
-        # For example, /api/person/1.
-        blueprint.add_url_rule(collection_endpoint,
-                               defaults={'instid': None, 'relationname': None,
-                                         'relationinstid': None},
-                               methods=possibly_empty_instance_methods,
-                               view_func=api_view)
+
         # the per-instance endpoints will allow both integer and string primary
         # key accesses
         instance_endpoint = '%s/<instid>' % (collection_endpoint)
-        # For example, /api/person/1.
-        blueprint.add_url_rule(instance_endpoint, methods=instance_methods,
-                               defaults={'relationname': None,
-                                         'relationinstid': None},
-                               view_func=api_view)
-        # add endpoints which expose related models
-        relation_endpoint = '%s/<relationname>' % (instance_endpoint)
-        relation_instance_endpoint = '%s/<relationinstid>' % relation_endpoint
-        # For example, /api/person/1/computers.
-        blueprint.add_url_rule(relation_endpoint,
-                               methods=possibly_empty_instance_methods,
-                               defaults={'relationinstid': None},
-                               view_func=api_view)
-        # For example, /api/person/1/computers/2.
-        blueprint.add_url_rule(relation_instance_endpoint,
-                               methods=instance_methods,
-                               view_func=api_view)
-        # if function evaluation is allowed, add an endpoint at /api/eval/...
-        # which responds only to GET requests and responds with the result of
-        # evaluating functions on all instances of the specified model
-        if allow_functions:
-            eval_api_name = apiname + 'eval'
-            eval_api_view = FunctionAPI.as_view(eval_api_name, self.session,
-                                                model)
-            eval_endpoint = '/eval' + collection_endpoint
-            blueprint.add_url_rule(eval_endpoint, methods=['GET'],
-                                   view_func=eval_api_view)
+
+        if relationname:
+            # add endpoints which expose related models
+            relation_endpoint = '%s/%s' % (instance_endpoint, relationname)
+            relation_instance_endpoint = '%s/<relationinstid>' % relation_endpoint
+            # For example, /api/person/1/computers.
+            blueprint.add_url_rule(relation_endpoint,
+                                   methods=possibly_empty_instance_methods,
+                                   defaults={'relationinstid': None,
+                                             'relationname': relationname},
+                                   view_func=api_view)
+            # For example, /api/person/1/computers/2.
+            blueprint.add_url_rule(relation_instance_endpoint,
+                                   defaults={'relationname': relationname},
+                                   methods=instance_methods,
+                                   view_func=api_view)
+        else:
+            # For example, /api/person.
+            blueprint.add_url_rule(collection_endpoint,
+                                   methods=no_instance_methods,
+                                   view_func=api_view)
+            # For example, /api/person/1.
+            blueprint.add_url_rule(collection_endpoint,
+                                   defaults={'instid': None,
+                                             'relationname': None,
+                                             'relationinstid': None},
+                                   methods=possibly_empty_instance_methods,
+                                   view_func=api_view)
+            # For example, /api/person/1.
+            blueprint.add_url_rule(instance_endpoint, methods=instance_methods,
+                                   defaults={'relationname': None,
+                                             'relationinstid': None},
+                                   view_func=api_view)
+            # if function evaluation is allowed, add an endpoint at
+            # /api/eval/...  which responds only to GET requests and responds
+            # with the result of evaluating functions on all instances of the
+            # specified model
+            if allow_functions:
+                eval_api_name = apiname + 'eval'
+                eval_api_view = FunctionAPI.as_view(eval_api_name, self.session,
+                                                    model)
+                eval_endpoint = '/eval' + collection_endpoint
+                blueprint.add_url_rule(eval_endpoint, methods=['GET'],
+                                       view_func=eval_api_view)
+
         return blueprint
 
     def create_api(self, *args, **kw):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -247,8 +247,8 @@ class TestAPIManager(TestSupport):
         for column in 'name', 'age', 'other', 'birth_date', 'computers':
             assert column in loads(response.data)
         response = self.app.get('/all2/person/%s' % personid)
-        for column in 'name', 'age', 'other', 'birth_date', 'computers':
-            assert column in loads(response.data)
+        for column in 'name', 'age', 'other', 'birth_date', 'is_minor':
+            assert column in loads(response.data), column
 
         # get some
         response = self.app.get('/some/person/%s' % personid)
@@ -472,26 +472,8 @@ class TestAPIManager(TestSupport):
         self.session.commit()
 
         self.manager.create_api(self.Person)
+        self.manager.create_api(self.Person, relationname='computers')
         response = self.app.get('/api/person/1/computers')
-        assert 200 == response.status_code
-        data = loads(response.data)
-        assert 'objects' in data
-        assert 1 == len(data['objects'])
-        assert 'foo' == data['objects'][0]['name']
-
-    def test_expose_lazy_relations(self):
-        """Tests that lazy relations are exposed at a URL which is a child of
-        the instance URL.
-
-        """
-        person = self.LazyPerson(name='Test')
-        computer = self.LazyComputer(name='foo')
-        self.session.add(person)
-        person.computers.append(computer)
-        self.session.commit()
-
-        self.manager.create_api(self.LazyPerson)
-        response = self.app.get('/api/lazyperson/1/computers')
         assert 200 == response.status_code
         data = loads(response.data)
         assert 'objects' in data

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -278,6 +278,9 @@ class TestAPI(TestSupport):
         # setup the URLs for the Person and Computer API
         self.manager.create_api(self.Person,
                                 methods=['GET', 'PATCH', 'POST', 'DELETE'])
+        self.manager.create_api(self.Person,
+                                relationname='computers',
+                                methods=['GET', 'PATCH', 'POST', 'DELETE'])
         self.manager.create_api(self.Computer,
                                 methods=['GET', 'POST', 'PATCH'])
 


### PR DESCRIPTION
Enables explicit declaration of exposed model sub-resources by
passing a `relationname` parameter to the `APIManager.create_api`
method.

This enables model relation endpoints to declare their own include and
exclude rules, methods, and post and pre processors.

If relationname is not passed to `create_api`, only the primary model
endpoints are created (e.g. /api/person, /api/person/1) you won't be
able to access other endpoints. Additional calls to `create_api` which
include the `relationname` parameter create the relation endpoints and
at this point include and exclude rules as well as post and pre
processors can be passed (Same as the primary model or different).

This also enables filtering of exposed relations using the same API.

This introduces two backwards incompatible changes.

1) Each exposed relation endpoint needs to be defined using `create_api`
   and passing the `relationname` parameter.

2) When passing `exclude_columns`, if you wish to exclude all relational data
   in a field, you only need to pass the field name, and not each field
   under the relation. For example,

   ```exclude_columns = ['country']```

   Instead of

   ```exclude_columns = ['country.name', 'country.code']```

This commit also updates the `has_field` doc string, which should also work
for `hybrid_property` fields.

An example declaration exposing a primary resource and a sub-resource:

```
apimanager.create_api(Country,
        methods=methods,
        url_prefix="/api/v1",
        results_per_page=results_per_page,
        max_results_per_page=100000,
        postprocessors=postprocessors_,
        preprocessors=preprocessors_,
        allow_functions=allow_functions,
        exclude_columns=[],
        include_columns=[],
        validation_exceptions=[ValidationError,
            ProcessingException,
            BadRequest],
        )

apimanager.create_api(Country,
        relationname='cities',
        methods=methods,
        url_prefix="/api/v1",
        results_per_page=results_per_page,
        max_results_per_page=100000,
        postprocessors=postprocessors_,
        preprocessors=preprocessors_,
        allow_functions=allow_functions,
        exclude_columns=[],
        include_columns=[],
        validation_exceptions=[ValidationError,
            ProcessingException,
            BadRequest],
        )
```
