### PR TITLE
Extract model pk before postprocessors are called

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1135,7 +1135,7 @@ class API(ModelView):
             self.session.commit()
             result = self._inst_to_dict(instance)
             primary_key = str(result[primary_key_name(instance)])
-            
+
             for postprocessor in self.postprocessors['POST']:
                 postprocessor(result=result)
 


### PR DESCRIPTION
This prevents problems when the pk field is renamed, removed or moved to a nested dict in a postprocessor.
