### PR TITLE
Return 404 on empty search result

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -922,7 +922,7 @@ class API(ModelView):
         try:
             result = search(self.session, self.model, search_params)
         except NoResultFound:
-            return jsonify_status_code(400, message='No result found')
+            return jsonify_status_code(404, message='No result found')
         except MultipleResultsFound:
             return jsonify_status_code(400, message='Multiple results found')
         except Exception, exception:


### PR DESCRIPTION
An empty result should return a 404 not a 400.

At least that's what I would expect. Offering this PR in case it's needed
