### PR TITLE
Method check with include_methods

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -313,7 +313,7 @@ def to_dict(instance, deep=None, exclude=None, include=None,
     if include_methods is not None:
         result.update(dict((method, getattr(instance, method)())
                            for method in include_methods
-                           if not '.' in method))
+                           if not '.' in method and hasattr(instance, method)))
     # Check for objects in the dictionary that may not be serializable by
     # default. Specifically, convert datetime and date objects to ISO 8601
     # format, and convert UUID objects to hexadecimal strings.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -180,6 +180,27 @@ class TestModelHelpers(TestSupport):
         assert 'first_computer' in data
         assert 'foo' == data['first_computer']['name']
 
+    def test_missing_method(self):
+        """Test missing attr is handled gracefully when parsing
+        include_methods"""
+
+        # When getting at data via an instance (/user/id/computer) and
+        # user has a 'include_method' set, to_dict errors when getattr
+        # runs on the computer instance, as it tries to include_method
+        # from user on computer object. Make sure this is handled
+        # gracefully (i.e. skipped)
+        # In this test we just use an invalid include_methods on
+        # computer as it generates the same error
+
+        person = self.Person(name='Test', age=10, other=20)
+        computer = self.Computer(name='foo')
+        person.computers.append(computer)
+
+        data = to_dict(computer, include_methods=['first_computer'])
+
+        assert 'first_computer' not in data
+
+
     def test_get_columns(self):
         """Test for getting the names of columns as strings."""
         columns = get_columns(self.Person)


### PR DESCRIPTION
Fixes a problem when accessing a relation. 
For example having a user endpoint with include_method 'first_computer' and then accessing

  /api/users/1/computers

will throw an AttributeError when trying to get the 'first_computer' attr from computer. This happens because we are getting at it via /api/users.

This patch checks the attribute exists on the instance to prevent the exception.