### PR TITLE
convert integers in JSON responses to intervals in SQL

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -15,6 +15,7 @@ import uuid
 from dateutil.parser import parse as parse_datetime
 from sqlalchemy import Date
 from sqlalchemy import DateTime
+from sqlalchemy import Interval
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.associationproxy import AssociationProxy
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -141,11 +142,8 @@ def has_field(model, fieldname):
             not isinstance(getattr(model, fieldname), _BinaryExpression))
 
 
-def is_date_field(model, fieldname):
-    """Returns ``True`` if and only if the field of `model` with the specified
-    name corresponds to either a :class:`datetime.date` object or a
-    :class:`datetime.datetime` object.
-
+def get_field_type(model, fieldname):
+    """Helper which returns the SQLAlchemy type of the field.
     """
     field = getattr(model, fieldname)
     if isinstance(field, ColumnElement):
@@ -156,11 +154,28 @@ def is_date_field(model, fieldname):
         if hasattr(field, 'property'):
             prop = field.property
             if isinstance(prop, RelProperty):
-                return False
+                return None
             fieldtype = prop.columns[0].type
         else:
-            return False
+            return None
+    return fieldtype
+
+
+def is_date_field(model, fieldname):
+    """Returns ``True`` if and only if the field of `model` with the specified
+    name corresponds to either a :class:`datetime.date` object or a
+    :class:`datetime.datetime` object.
+    """
+    fieldtype = get_field_type(model, fieldname)
     return isinstance(fieldtype, Date) or isinstance(fieldtype, DateTime)
+
+
+def is_interval_field(model, fieldname):
+    """Returns ``True`` if and only if the field of `model` with the specified
+    name corresponds to a :class:`datetime.timedelta` object.
+    """
+    fieldtype = get_field_type(model, fieldname)
+    return isinstance(fieldtype, Interval)
 
 
 def assign_attributes(model, **kwargs):
@@ -486,15 +501,16 @@ def get_or_create(session, model, attrs):
 
 def strings_to_dates(model, dictionary):
     """Returns a new dictionary with all the mappings of `dictionary` but
-    with date strings mapped to :class:`datetime.datetime` objects.
+    with date strings and intervals mapped to :class:`datetime.datetime` or
+    :class:`datetime.timedelta` objects.
 
     The keys of `dictionary` are names of fields in the model specified in the
     constructor of this class. The values are values to set on these fields. If
     a field name corresponds to a field in the model which is a
-    :class:`sqlalchemy.types.Date` or :class:`sqlalchemy.types.DateTime`, then
-    the returned dictionary will have the corresponding
-    :class:`datetime.datetime` Python object as the value of that mapping in
-    place of the string.
+    :class:`sqlalchemy.types.Date`, :class:`sqlalchemy.types.DateTime`, or
+    :class:`sqlalchemy.Interval`, then the returned dictionary will have the
+    corresponding :class:`datetime.datetime` or :class:`datetime.timedelta`
+    Python object as the value of that mapping in place of the string.
 
     This function outputs a new dictionary; it does not modify the argument.
 
@@ -508,6 +524,9 @@ def strings_to_dates(model, dictionary):
                 result[fieldname] = getattr(func, value.lower())()
             else:
                 result[fieldname] = parse_datetime(value)
+        elif is_interval_field(model, fieldname) and value is not None\
+            and isinstance(value, int):
+            result[fieldname] = datetime.timedelta(seconds=value)
         else:
             result[fieldname] = value
     return result

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,6 +20,7 @@ from sqlalchemy import DateTime
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
+from sqlalchemy import Interval
 from sqlalchemy import Boolean
 from sqlalchemy import Unicode
 from sqlalchemy.dialects.postgresql import UUID
@@ -239,6 +240,11 @@ class TestSupport(DatabaseTestBase):
             __tablename__ = 'planet'
             name = Column(Unicode, primary_key=True)
 
+        class Satellite(self.Base):
+            __tablename__ = 'satellite'
+            name = Column(Unicode, primary_key=True)
+            period = Column(Interval, nullable=True)
+
         class Star(self.Base):
             __tablename__ = 'star'
             id = Column("star_id", Integer, primary_key=True)
@@ -271,6 +277,7 @@ class TestSupport(DatabaseTestBase):
         self.LazyPerson = LazyPerson
         self.Computer = Computer
         self.Planet = Planet
+        self.Satellite = Satellite
         self.Star = Star
         self.Vehicle = Vehicle
         self.CarManufacturer = CarManufacturer

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -11,6 +11,7 @@
 """
 from datetime import date
 from datetime import datetime
+from datetime import timedelta
 
 import dateutil
 from flask import json
@@ -400,6 +401,24 @@ class TestAPI(TestSupport):
         diff = datetime.utcnow() - inception_time
         assert diff.days == 0
         assert (diff.seconds + diff.microseconds / 1000000.0) < 3600
+
+    def test_post_interval_functions(self):
+        oldJSONEncoder = self.flaskapp.json_encoder
+        class IntervalJSONEncoder(oldJSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, timedelta):
+                    return int(obj.days*86400 + obj.seconds)
+                return oldJSONEncoder.default(self, obj)
+        self.flaskapp.json_encoder = IntervalJSONEncoder
+
+        self.manager.create_api(self.Satellite, methods=['GET', 'POST'])
+        data = dict(name="Callufrax_Minor", period=300)
+        response = self.app.post('/api/satellite', data=dumps(data))
+        assert response.status_code == 201
+        response = self.app.get('/api/satellite/Callufrax_Minor')
+        assert response.status_code == 200
+        assert loads(response.data)['period'] == 300
+        assert self.session.query(self.Satellite).all()[0].period == timedelta(0, 300)
 
     def test_post_with_submodels(self):
         """Tests the creation of a model with a related field."""


### PR DESCRIPTION
This adds handling of SQL interval types in the same way Flask-Restless handles SQL date & datetime types. A request containing an integer value for a column which is of the interval type is treated as an integer number of seconds and converted to a `datetime.timedelta` type. String values for interval types are left un-modified (PostgreSQL at least will correctly parse intervals strings like `"2 days"` as well as `"1:23:45"`. 

Flask's default JSON encoder doesn't support `timedelta` types, so the test is a bit more complicated. Automatic handling of interval types in Flask-Restless could be added here as well. IMHO, interval types are widely enough used that it would be helpful if they just worked flawlessly. 
