### PR TITLE
Inconsistent doc in example and website

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -10,7 +10,7 @@ db = flask.ext.sqlalchemy.SQLAlchemy(app)
 
 # Create your Flask-SQLALchemy models as usual but with the following two
 # (reasonable) restrictions:
-#   1. They must have an id column of type Integer.
+#   1. They must have an id column of type Integer or Unicode.
 #   2. They must have an __init__ method which accepts keyword arguments for
 #      all columns (the constructor in flask.ext.sqlalchemy.SQLAlchemy.Model
 #      supplies such a method, so you don't need to declare a new one).


### PR DESCRIPTION
```
# Create your Flask-SQLALchemy models as usual but with the following two
# (reasonable) restrictions:
#   1. They must have an id column of type Integer.
```

ref: https://flask-restless.readthedocs.org/en/latest/quickstart.html

```
 They must have a primary key column of type sqlalchemy.Integer or type sqlalchemy.Unicode.
```

ref: https://flask-restless.readthedocs.org/en/latest/basicusage.html

Is my assumption is right that Unicode is also valid id?
