### PR TITLE
Catch invalid datetime string as Validation error (400) instead of inter...

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -544,7 +544,11 @@ def strings_to_dates(model, dictionary):
             elif value in CURRENT_TIME_MARKERS:
                 result[fieldname] = getattr(func, value.lower())()
             else:
-                result[fieldname] = parse_datetime(value)
+                try:
+                    result[fieldname] = parse_datetime(value)
+                except ValueError as exception:
+                    error_message = "Cannot validate %s with value %s: %s" % (fieldname, value, str(exception))
+                    raise ValueError(error_message)
         elif (is_interval_field(model, fieldname) and value is not None
               and isinstance(value, int)):
             result[fieldname] = datetime.timedelta(seconds=value)

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1195,7 +1195,11 @@ class API(ModelView):
 
         # Special case: if there are any dates, convert the string form of the
         # date into an instance of the Python ``datetime`` object.
-        params = strings_to_dates(self.model, params)
+        try:
+            params = strings_to_dates(self.model, params)
+        except ValueError as exception:
+            current_app.logger.exception(str(exception))
+            return dict(validation_errors=str(exception)), 400
 
         try:
             # Instantiate the model with the parameters.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -425,6 +425,20 @@ class TestAPI(TestSupport):
         assert response.status_code == 200
         assert loads(response.data)['inception_time'] is None
 
+    def test_post_valid_date_string(self):
+        self.manager.create_api(self.Star, methods=['POST'])
+        data = dict(inception_time="2013-03-02")
+        response = self.app.post('/api/star', data=dumps(data))
+
+        assert response.status_code == 201
+
+    def test_post_invalid_date_string(self):
+        self.manager.create_api(self.Star, methods=['POST'])
+        data = dict(inception_time="0000-00-00")
+        response = self.app.post('/api/star', data=dumps(data))
+
+        assert response.status_code == 400
+
     def test_post_date_functions(self):
         """Tests that ``'CURRENT_TIMESTAMP'`` gets converted into a datetime
         object when making a request to set a date or time field.


### PR DESCRIPTION
...nal server error (500)

TL;DR
Return a 400 when invalid datetime string is given.

Currently when I post a datetime string, for example "0000-00-00", I receive a 500 returncode, which is equal to an internal server error. The traceback of flask shows "ValueError: month must be in 1..12".

What makes more sense to me is a 400 returncode with a Validation Error message.
