### PR TITLE
fix #304

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -347,8 +347,8 @@ def _parse_excludes(column_names):
 #: :class:`mimerender.FlaskMimeRender` class. The second pair of parentheses
 #: creates the decorator, so that we can simply use the variable ``mimerender``
 #: as a decorator.
-mimerender = FlaskMimeRender()(default='json', json=jsonpify,
-                               xml=lambda: None)  # TODO fill in xml renderer
+# TODO fill in xml renderer
+mimerender = FlaskMimeRender()(default='json', json=jsonpify)
 
 
 class ModelView(MethodView):


### PR DESCRIPTION
The XML renderer stub breaks Flask-Restless when visting an API endpoint in Chrome.

No additional test as the fix is straightforward and a distinct test should becomes obsolete as soon as a xml renderer is implemented.

fixes #304 
