### PR TITLE
Only use count() optimization if there are no joins

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -561,6 +561,8 @@ def count(session, query):
     queries.
 
     """
-    counts = query.statement.with_only_columns([func.count()])
-    num_results = session.execute(counts.order_by(None)).scalar()
+    num_results = None
+    if len(query.statement._froms) == 1:
+        counts = query.statement.with_only_columns([func.count()])
+        num_results = session.execute(counts.order_by(None)).scalar()
     return query.count() if num_results is None else num_results

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1816,7 +1816,7 @@ class TestAssociationProxy(DatabaseTestBase):
             chosen_images = prox('chosen_product_images', 'image',
                                  creator=creator2)
             image_names = prox('chosen_product_images', 'name')
-            tags = rel(Tag, secondary=tag_product,
+            tags = rel(Tag, secondary=tag_product, lazy='joined',
                        backref=backref(name='products', lazy='dynamic'))
             tag_names = prox('tags', 'name',
                              creator=lambda tag_name: Tag(name=tag_name))
@@ -2066,3 +2066,12 @@ class TestAssociationProxy(DatabaseTestBase):
         data = loads(response.data)
 
         assert sorted(data['tag_names']), sorted(['tag1' == 'tag2'])
+
+    def test_num_results(self):
+        self.session.add(self.Product(tag_names=['tag1', 'tag2']))
+        self.session.commit()
+
+        response = self.app.get('/api/product')
+        assert response.status_code == 200
+        data = loads(response.data)
+        assert data['num_results'] == 1


### PR DESCRIPTION
The `count()` helper optimization only works if the current `query.statement` performs no `JOIN`s.
However, if a relation is set to use joined-load, the current `query.statement` will perform a
`JOIN`, and the `count()` helper will return the number of rows in the `JOIN` (that is, the number of objects found for the current endpoint _multiplied_ by the number of objects in each joined-loaded relation), not the number of objects that will be returned.
