### PR TITLE
fixed ProcessingException message serialization

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -139,7 +139,7 @@ def catch_processing_exceptions(func):
             return func(*args, **kw)
         except ProcessingException as exception:
             current_app.logger.exception(str(exception))
-            status, message = exception.code, str(exception)
+            status, message = exception.code, exception.description or str(exception)
             return jsonify(message=message), status
     return decorator
 


### PR DESCRIPTION
There's slight inconsistency in handling ProcessingException. Its `description` field is being set but ignored when serializing response. Please consider merging this simple fix, so we can have meaningful error messages.
