### PR TITLE
use query.selectable instead of query.statement in count helper

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -562,7 +562,6 @@ def count(session, query):
 
     """
     num_results = None
-    if len(query.statement._froms) == 1:
-        counts = query.statement.with_only_columns([func.count()])
-        num_results = session.execute(counts.order_by(None)).scalar()
+    counts = query.selectable.with_only_columns([func.count()])
+    num_results = session.execute(counts.order_by(None)).scalar()
     return query.count() if num_results is None else num_results


### PR DESCRIPTION
This is a better fix for #309.

Using `query.statement` generates a warning about not having labels; while investigating this warning, it seemed like `query.statement` is more for internal SQLAlchemy use, and `query.selectable` was what we should be using. In addition, `selectable` does not raise these warnings, and also does not suffer from the problem with joins that `statement` did, fixed in #309.

This is the warning that was raised, in `tests.test_views.TestAssociationProxy.test_num_results`:

```
/Users/matt/programs/flask-restless/SQLAlchemy-0.9.4-py2.7.egg/sqlalchemy/sql/base.py:490: SAWarning: Column 'id' on table <sqlalchemy.sql.selectable.Select at 0x1102cced0; Select object> being replaced by Column('id', Integer(), table=<Select object>, primary_key=True, nullable=False), which has the same key.  Consider use_labels for select() statements.
  self[column.key] = column
```
