### PR TITLE
make PATCH respect specified primary_key

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1325,7 +1325,7 @@ class API(ModelView):
                 return dict(message='Unable to construct query'), 400
         else:
             # create a SQLAlchemy Query which has exactly the specified row
-            query = query_by_primary_key(self.session, self.model, instid)
+            query = query_by_primary_key(self.session, self.model, instid, self.primary_key)
             if query.count() == 0:
                 return {_STATUS: 404}, 404
             assert query.count() == 1, 'Multiple rows with same ID'


### PR DESCRIPTION
When I specify the primary key (eg `manager.create_api(User, primary_key='username')`), trying to do a PUT or PATCH was returning 404 errors. This change fixes that for me.
