### PR TITLE
fixes to DELETE method handling

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1091,9 +1091,11 @@ class API(ModelView):
         """Removes the specified instance of the model with the specified name
         from the database.
 
-        Since :http:method:`delete` is an idempotent method according to the
-        :rfc:`2616`, this method responds with :http:status:`204` regardless of
-        whether an object was deleted.
+        Although :http:method:`delete` is an idempotent method according to
+        :rfc:`2616`, idempotency only means that subsequent identical requests
+        cannot have additional side-effects. Since the response code is not a
+        side effect, this method responds with :http:status:`204` only if an
+        object is deleted, and with :http:status:`404` when nothing is deleted.
 
         If `relationname
 
@@ -1122,13 +1124,14 @@ class API(ModelView):
                                        relationinstid)
             # Removes an object from the relation list.
             relation.remove(relation_instance)
+            is_deleted = len(self.session.dirty) > 0
         elif inst is not None:
             self.session.delete(inst)
-            is_deleted = True
+            is_deleted = len(self.session.deleted) > 0
         self.session.commit()
         for postprocessor in self.postprocessors['DELETE']:
             postprocessor(is_deleted=is_deleted)
-        return {}, 204
+        return {}, 204 if is_deleted else 404
 
     def post(self):
         """Creates a new instance of a given model based on request data.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -692,12 +692,11 @@ class TestAPI(TestSupport):
         """Test that deleting an instance of the model which does not exist
         fails.
 
-        This should give us the same response as when there is an object there,
-        since the :http:method:`delete` method is an idempotent method.
+        This should give us a 404 when the object is not found.
 
         """
         response = self.app.delete('/api/person/1')
-        assert response.status_code == 204
+        assert response.status_code == 404
 
     def test_disallow_patch_many(self):
         """Tests that disallowing "patch many" requests responds with a


### PR DESCRIPTION
- the if-block for deleting an object from a relation was not committing; the tests were still passing because the session was still open and the next API call would pull the object out of the session, not the DB. Put a `session.remove()` before the API call to check that the removed object is actually gone from the relation, and you'll see that it's still there in the DB.
- Idempotency only means that subsequent identical requests cannot have
  additional side-effects. Since the response code is not a side effect,
  but rather a return value, `DELETE` should respond with `204` only if
  an object is deleted, and with `404` when nothing is deleted.
  (It is very confusing if an API returns `204` to a DELETE for a nonexistent
  or inaccessible resource.)
