### PR TITLE
Pass the request as a parameter to the preprocessor

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -981,7 +981,7 @@ class API(ModelView):
             return dict(message='Unable to decode data'), 400
 
         for preprocessor in self.preprocessors['GET_MANY']:
-            preprocessor(search_params=search_params)
+            preprocessor(search_params=search_params, request=request)
 
         # perform a filtered search
         try:


### PR DESCRIPTION
This would allow us to access other arguments of the request when implementing preprocessors.

In my specific case, I'm trying to preprocess a request sent by a Backgrid.js based frontend which sets the parameters of the request as strings using a one-by-one mapping from fontend state parameters.  By accessing these string parameters I could then build in the preprocessor the `search_params` dict that flask-restless is expecting.

In a more general case this gives more power to the preprocessors.
