### PR TITLE
don't bother with count() if a limit has already been set

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -561,6 +561,8 @@ def count(session, query):
     queries.
 
     """
+    if query._limit:
+        return query._limit
     num_results = None
     counts = query.selectable.with_only_columns([func.count()])
     num_results = session.execute(counts.order_by(None)).scalar()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1694,6 +1694,23 @@ class TestSearch(TestSupportPrefilled):
         resp = self.app.search('/api/person', dumps(search))
         assert resp.status_code == 200
         assert 1 == len(loads(resp.data)['objects'])
+        assert loads(resp.data)['num_results'] == 1
+        assert loads(resp.data)['objects'][0]['name'] == u'Mary'
+
+        # Testing limit by itself
+        search = {'limit': 1}
+        resp = self.app.search('/api/person', dumps(search))
+        assert resp.status_code == 200
+        assert 1 == len(loads(resp.data)['objects'])
+        assert loads(resp.data)['num_results'] == 1
+        assert loads(resp.data)['objects'][0]['name'] == u'Lincoln'
+
+        # Testing offset by itself
+        search = {'offset': 1}
+        resp = self.app.search('/api/person', dumps(search))
+        assert resp.status_code == 200
+        assert 4 == len(loads(resp.data)['objects'])
+        assert loads(resp.data)['num_results'] == 4
         assert loads(resp.data)['objects'][0]['name'] == u'Mary'
 
         # Testing multiple results when calling .one()


### PR DESCRIPTION
the constructed query for count below strips off any limit and offset, and if limit is specified without offset, it returns the whole count, not the limited count.
