### PR TITLE
Fix count() when LIMIT is set

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -564,4 +564,4 @@ def count(session, query):
     num_results = None
     counts = query.selectable.with_only_columns([func.count()])
     num_results = session.execute(counts.order_by(None)).scalar()
-    return query.count() if num_results is None else num_results
+    return query.count() if num_results is None or query._limit else num_results

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1694,6 +1694,30 @@ class TestSearch(TestSupportPrefilled):
         resp = self.app.search('/api/person', dumps(search))
         assert resp.status_code == 200
         assert 1 == len(loads(resp.data)['objects'])
+        assert loads(resp.data)['num_results'] == 1
+        assert loads(resp.data)['objects'][0]['name'] == u'Mary'
+
+        # Testing limit by itself
+        search = {'limit': 1}
+        resp = self.app.search('/api/person', dumps(search))
+        assert resp.status_code == 200
+        assert 1 == len(loads(resp.data)['objects'])
+        assert loads(resp.data)['num_results'] == 1
+        assert loads(resp.data)['objects'][0]['name'] == u'Lincoln'
+
+        search = {'limit': 5000}
+        resp = self.app.search('/api/person', dumps(search))
+        assert resp.status_code == 200
+        assert 5 == len(loads(resp.data)['objects'])
+        assert loads(resp.data)['num_results'] == 5
+        assert loads(resp.data)['objects'][0]['name'] == u'Lincoln'
+
+         # Testing offset by itself
+        search = {'offset': 1}
+        resp = self.app.search('/api/person', dumps(search))
+        assert resp.status_code == 200
+        assert 4 == len(loads(resp.data)['objects'])
+        assert loads(resp.data)['num_results'] == 4
         assert loads(resp.data)['objects'][0]['name'] == u'Mary'
 
         # Testing multiple results when calling .one()


### PR DESCRIPTION
Using just a limit in search_params, the limit is not enforced. In helpers.count() num_results always contains the full count. This change forces the use of query.count() when a LIMIT is set.
