### PR TITLE
Improving tests

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from .helpers import FlaskTestBase
 from .helpers import skip_unless
 from .helpers import TestSupport
+from .helpers import unregister_fsa_session_signals
 
 
 dumps = json.dumps
@@ -644,6 +645,7 @@ class TestFSA(FlaskTestBase):
     def tearDown(self):
         """Drops all tables from the temporary database."""
         self.db.drop_all()
+        unregister_fsa_session_signals()
 
     def test_flask_sqlalchemy(self):
         """Tests that :class:`flask.ext.restless.APIManager` correctly exposes

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -40,6 +40,7 @@ from .helpers import FlaskTestBase
 from .helpers import skip_unless
 from .helpers import TestSupport
 from .helpers import TestSupportPrefilled
+from .helpers import unregister_fsa_session_signals
 
 
 dumps = json.dumps
@@ -97,6 +98,7 @@ class TestFSAModel(FlaskTestBase):
     def tearDown(self):
         """Drops all tables."""
         self.db.drop_all()
+        unregister_fsa_session_signals()
 
     def test_get(self):
         """Test for the :meth:`views.API.get` method with models defined using


### PR DESCRIPTION
Some changes on `skip_unless` and Flask-SQLAlchemy testing. 
- `skip_unless` now handles correct decoration of classes;
- After applying `skip_unless`-related changes some tests started to fail (because they started to execute). After some invastigation I have found that using both _default sqlalchemy_ and _Flask-SQLAlchemy_ sessions is not so obvious.
  The whole thing was that Flask-SQLAlchemys' class `SQLAlchemy` registered some global handlers for session signals. This was the reason of test failures. So, I've added unregistering this handlers on `tearDown` in all Flask-SQLAlchemy tests.
