### PR TITLE
Fixed get_related_model with hybrid_property.expression

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -126,8 +126,8 @@ def get_related_model(model, relationname):
         if hasattr(attr, 'property') \
                 and isinstance(attr.property, RelProperty):
             return attr.property.mapper.class_
-    if isinstance(attr, AssociationProxy):
-        return get_related_association_proxy_model(attr)
+        if isinstance(attr, AssociationProxy):
+            return get_related_association_proxy_model(attr)
     return None
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -35,6 +35,7 @@ from sqlalchemy import Float
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import Interval
+from sqlalchemy import select
 from sqlalchemy import Time
 from sqlalchemy import Unicode
 from sqlalchemy.dialects.postgresql import UUID
@@ -265,6 +266,17 @@ class TestSupport(DatabaseTestBase):
                 if getattr(self, 'age') is None:
                     return None
                 return self.age < 18
+
+            @hybrid_property
+            def is_above_21(self):
+                if getattr(self, 'age') is None:
+                    return None
+                return self.age > 21
+
+            @is_above_21.expression
+            def is_above_21(cls):
+                return select([cls.age > 21]).as_scalar()
+
 
             def name_and_age(self):
                 return "{0} (aged {1:d})".format(self.name, self.age)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -28,6 +28,7 @@ from flask.ext.restless.helpers import to_dict
 from flask.ext.restless.helpers import upper_keys
 from flask.ext.restless.helpers import get_by
 from flask.ext.restless.helpers import is_like_list
+from flask.ext.restless.helpers import get_related_model
 
 from .helpers import TestSupport
 from .helpers import TestSupportPrefilled
@@ -153,7 +154,7 @@ class TestModelHelpers(TestSupport):
 
         me_dict = to_dict(me)
         expectedfields = sorted(['birth_date', 'age', 'id', 'name',
-                                 'other', 'is_minor'])
+                                 'other', 'is_minor', 'is_above_21'])
         assert sorted(me_dict) == expectedfields
         assert me_dict['name'] == u'Lincoln'
         assert me_dict['age'] == 24
@@ -236,6 +237,7 @@ class TestModelHelpers(TestSupport):
         assert sorted(columns.keys()) == sorted(['age', 'birth_date',
                                                  'computers',
                                                  'id',
+                                                 'is_above_21',
                                                  'is_minor',
                                                  'name',
                                                  'other'])
@@ -259,6 +261,14 @@ class TestModelHelpers(TestSupport):
 
         assert is_like_list(proof, 'person') == False
         assert is_like_list(proof, 'person_id') == False
+
+    def test_get_related_model(self):
+        """Test the get_related_model method."""
+
+        assert get_related_model(self.Person, 'is_minor') is None,\
+            'Person.is_minor should not have a model'
+        assert get_related_model(self.Person, 'is_above_21') is None,\
+            'Person.is_above_21 should not have a model'
 
 
 class TestFunctionEvaluation(TestSupportPrefilled):


### PR DESCRIPTION
Previously when using a `hybrid_property.expression`, the `get_related_model()` function would throw an exception like:

```
  [...]
  File "..python3.4/site-packages/flask_restless/views.py", line 1056, in get
    return self._search()
  File "..python3.4/site-packages/flask_restless/views.py", line 999, in _search
    relations = frozenset(get_relations(self.model))
  File "..python3.4/site-packages/flask_restless/helpers.py", line 114, in get_relations
    return [k for k in dir(model)
  File "..python3.4/site-packages/flask_restless/helpers.py", line 116, in <listcomp>
    and get_related_model(model, k)]
  File "..python3.4/site-packages/flask_restless/helpers.py", line 129, in get_related_model
    if isinstance(attr, AssociationProxy):
UnboundLocalError: local variable 'attr' referenced before assignment
```

I believe the original code was just indented wrong accidentally.
