### PR TITLE
Allow POST and PATCH requests to modify hybrid properties.

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -145,15 +145,6 @@ def get_related_association_proxy_model(attr):
     return None
 
 
-def has_field(model, fieldname):
-    """Returns ``True`` if the `model` has the specified field, and it is not
-    a hybrid property.
-
-    """
-    return (hasattr(model, fieldname) and
-            not isinstance(getattr(model, fieldname), _BinaryExpression))
-
-
 def get_field_type(model, fieldname):
     """Helper which returns the SQLAlchemy type of the field.
     """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -252,6 +252,20 @@ class TestSupport(DatabaseTestBase):
             def speed(self):
                 return 42
 
+        class Screen(self.Base):
+            __tablename__ = 'screen'
+            id = Column(Integer, primary_key=True)
+            width = Column(Integer, nullable=False)
+            height = Column(Integer, nullable=False)
+
+            @hybrid_property
+            def number_of_pixels(self):
+                return self.width * self.height
+
+            @number_of_pixels.setter
+            def number_of_pixels(self, value):
+                self.height = value / self.width
+
         class Person(self.Base):
             __tablename__ = 'person'
             id = Column(Integer, primary_key=True)
@@ -367,6 +381,7 @@ class TestSupport(DatabaseTestBase):
         self.CarModel = CarModel
         self.Project = Project
         self.Proof = Proof
+        self.Screen = Screen
 
         # create all the tables required for the models
         self.Base.metadata.create_all()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -797,6 +797,8 @@ class TestAPI(TestSupport):
         assert 201 == response.status_code
         response = self.app.patch('/api/person/1', data=dumps(dict(bogus=0)))
         assert 400 == response.status_code
+        response = self.app.patch('/api/person/1', data=dumps(dict(is_minor=True)))
+        assert 400 == response.status_code
 
     def test_patch_many(self):
         """Test for updating a collection of instances of the model using the
@@ -1502,6 +1504,19 @@ class TestAPI(TestSupport):
         data = loads(response.data)
         assert 2 == data['other']
         assert 4 == data['sq_other']
+
+    def test_patch_with_hybrid_property(self):
+        """Tests that a hybrid property can be correctly posted from a client."""
+
+        self.session.add(self.Screen(id=1, width=5, height=4))
+        self.session.commit()
+        self.manager.create_api(self.Screen, methods=['PATCH'], collection_name='screen')
+        response = self.app.patch('/api/screen/1', data=dumps({"number_of_pixels": 50}))
+        assert 200 == response.status_code
+        data = loads(response.data)
+        assert 5 == data['width']
+        assert 10 == data['height']
+        assert 50 == data['number_of_pixels']
 
 
 class TestHeaders(TestSupportPrefilled):


### PR DESCRIPTION
The current implementations of [patch](https://github.com/jfinkels/flask-restless/blob/master/flask_restless/views.py#L1288) and [post](https://github.com/jfinkels/flask-restless/blob/master/flask_restless/views.py#L1165) are checking for any request parameter naming a column which does not exist on the current model.

``` python
for field in data:
    if not has_field(self.model, field):
        msg = "Model does not have field '{0}'".format(field)
        return dict(message=msg), 400
```

The [has_field](https://github.com/jfinkels/flask-restless/blob/master/flask_restless/helpers.py#L148) function returns `True` if the model has the specified field and **it is not a hybrid property**.

``` python
def has_field(model, fieldname):
    """Returns ``True`` if the `model` has the specified field, and it is not
    a hybrid property.

    """
    return (hasattr(model, fieldname) and
            not isinstance(getattr(model, fieldname), _BinaryExpression))
```

As a result posting or patching a model with some hybrid attributes will return a _status code 400_.

From the [SqlAlchemy documentation on Hybrid Attributes](http://docs.sqlalchemy.org/en/rel_0_7/orm/extensions/hybrid.html#defining-setters), it is possible to define a setter for an hybrid property. 

It would be very nice to be able to post or patch a model that has a settable hybrid property. 

For example, doing a :

``` python
self.app.post('/api/screen', data=dumps({"width": 5, "number_of_pixels": 50}))
```

On a model looking like this:

``` python
 class Screen(self.Base):
    __tablename__ = 'screen'
    id = Column(Integer, primary_key=True)
    width = Column(Integer, nullable=False)
    height = Column(Integer, nullable=False)

    @hybrid_property
    def number_of_pixels(self):
        return self.width * self.height

    @number_of_pixels.setter
    def number_of_pixels(self, value):
        self.height = value / self.width
```

Inside the patch and post implementation, I tried to find a way to detect if a hybrid property is settable or not without success. The [hybrid_property decorator implementation](https://github.com/zzzeek/sqlalchemy/blob/7fc08fe89af9760750899346cf81bd74e0d9150f/lib/sqlalchemy/ext/hybrid.py#L706) is overriding the `__set__` method and It's not easy to detect that. (any pointers welcome)

``` python
class hybrid_property(interfaces.InspectionAttr):
    """A decorator which allows definition of a Python descriptor with both
    instance-level and class-level behavior.

    """

    is_attribute = True
    extension_type = HYBRID_PROPERTY

    def __init__(self, fget, fset=None, fdel=None, expr=None):
        self.fget = fget
        self.fset = fset

    [...]

    def __set__(self, instance, value):
        if self.fset is None:
            raise AttributeError("can't set attribute")
        self.fset(instance, value)

    [...]
```

The cleanest way I found, to handle this, is to try to set the attribute and if `AttributeError("can't set attribute")` is raised, react accordingly. 

Let me know if there is things you like to see improved in the pull request. 

Fixes #320.
