### PR TITLE
Let hybrid properties, that are settable, be used when patching or posting.

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -146,12 +146,14 @@ def get_related_association_proxy_model(attr):
 
 
 def has_field(model, fieldname):
-    """Returns ``True`` if the `model` has the specified field, and it is not
-    a hybrid property.
+    """Returns ``True`` if the `model` has the specified field
+    or if it has a settable hybrid property for this field name.
 
     """
-    return (hasattr(model, fieldname) and
-            not isinstance(getattr(model, fieldname), _BinaryExpression))
+    descriptors_data = sqlalchemy_inspect(model).all_orm_descriptors._data
+    if fieldname in descriptors_data and hasattr(descriptors_data[fieldname], 'fset'):
+        return getattr(descriptors_data[fieldname], 'fset') is not None
+    return hasattr(model, fieldname)
 
 
 def get_field_type(model, fieldname):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -252,6 +252,20 @@ class TestSupport(DatabaseTestBase):
             def speed(self):
                 return 42
 
+        class Screen(self.Base):
+            __tablename__ = 'screen'
+            id = Column(Integer, primary_key=True)
+            width = Column(Integer, nullable=False)
+            height = Column(Integer, nullable=False)
+
+            @hybrid_property
+            def number_of_pixels(self):
+                return self.width * self.height
+
+            @number_of_pixels.setter
+            def number_of_pixels(self, value):
+                self.height = value / self.width
+
         class Person(self.Base):
             __tablename__ = 'person'
             id = Column(Integer, primary_key=True)
@@ -367,6 +381,7 @@ class TestSupport(DatabaseTestBase):
         self.CarModel = CarModel
         self.Project = Project
         self.Proof = Proof
+        self.Screen = Screen
 
         # create all the tables required for the models
         self.Base.metadata.create_all()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -797,6 +797,8 @@ class TestAPI(TestSupport):
         assert 201 == response.status_code
         response = self.app.patch('/api/person/1', data=dumps(dict(bogus=0)))
         assert 400 == response.status_code
+        response = self.app.patch('/api/person/1', data=dumps(dict(is_minor=True)))
+        assert 400 == response.status_code
 
     def test_patch_many(self):
         """Test for updating a collection of instances of the model using the
@@ -1502,6 +1504,19 @@ class TestAPI(TestSupport):
         data = loads(response.data)
         assert 2 == data['other']
         assert 4 == data['sq_other']
+
+    def test_patch_with_hybrid_property(self):
+        """Tests that a hybrid property can be correctly posted from a client."""
+
+        self.session.add(self.Screen(id=1, width=5, height=4))
+        self.session.commit()
+        self.manager.create_api(self.Screen, methods=['PATCH'], collection_name='screen')
+        response = self.app.patch('/api/screen/1', data=dumps({"number_of_pixels": 50}))
+        assert 200 == response.status_code
+        data = loads(response.data)
+        assert 5 == data['width']
+        assert 10 == data['height']
+        assert 50 == data['number_of_pixels']
 
 
 class TestHeaders(TestSupportPrefilled):


### PR DESCRIPTION
This pull request and the #359 pull request are fixing #320.

Instead of try catching errors when settings hybrid properties, this detects settable hybrid properties using the  SQLAlchemy Inspection API.
