### PR TITLE
Added ability to add additional messages in the ProcessingException JSON response.

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -540,8 +540,8 @@ authentication function can be implemented like this::
     manager.create_api(Person, preprocessors=dict(GET_SINGLE=[check_auth]))
 
 The :exc:`ProcessingException` allows you to specify an HTTP status code for
-the generated response and an error message which the client will receive as
-part of the JSON in the body of the response.
+the generated response, an error message, and optionally additional messages
+which the client will receive as part of the JSON in the body of the response.
 
 .. _universal:
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -540,8 +540,9 @@ authentication function can be implemented like this::
     manager.create_api(Person, preprocessors=dict(GET_SINGLE=[check_auth]))
 
 The :exc:`ProcessingException` allows you to specify an HTTP status code for
-the generated response, an error message, and optionally additional messages
-which the client will receive as part of the JSON in the body of the response.
+the generated response, an error message, and a dictionary of additional
+details which the client will receive as part of the JSON in the body of
+the response.
 
 .. _universal:
 

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -89,23 +89,22 @@ class ProcessingException(HTTPException):
 
     `status_code` is the HTTP status code of the response supplied to the
     client in the case that this exception is raised. `message` is an error
-    message describing the cause of this exception. `errors` is an optional
-    field giving extended details of the errors. The message and optional
-    errors will appear in the JSON object in the body of the response to
-    the client.
+    message describing the cause of this exception. `additional_messages` is
+    a dict containing additional messages to include in the json response.
+    The message and optional additional_messages will appear in the JSON
+    object in the body of the response to the client.
     """
-    def __init__(self, description='', code=400, errors=None, *args, **kwargs):
+    def __init__(self, description='', code=400, additional_messages=dict(),
+                 *args, **kwargs):
         super(ProcessingException, self).__init__(*args, **kwargs)
         self.code = code
         self.description = description
-        self.errors = errors
+        self.additional_messages=additional_messages
 
     def json_response(self):
         """Generates a JSON response for the Exception"""
         message = self.description or str(self)
-        if self.errors is not None:
-            return jsonify(message=message, errors=self.errors)
-        return jsonify(message=message)
+        return jsonify(message=message, **self.additional_messages)
 
 
 def _is_msie8or9():

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -88,23 +88,23 @@ class ProcessingException(HTTPException):
     the list will not be invoked.
 
     `status_code` is the HTTP status code of the response supplied to the
-    client in the case that this exception is raised. `message` is an error
-    message describing the cause of this exception. `additional_messages` is
-    a dict containing additional messages to include in the json response.
-    The message and optional additional_messages will appear in the JSON
-    object in the body of the response to the client.
+    client in the case that this exception is raised. `description` is an error
+    message describing the cause of this exception. `details` is a dictionary
+    containing additional messages to include in the JSON response. The
+    description and additional details will appear in the JSON object in
+    the body of the response to the client.
+
     """
-    def __init__(self, description='', code=400, additional_messages=dict(),
-                 *args, **kwargs):
+    def __init__(self, description='', code=400, details=None, *args, **kwargs):
         super(ProcessingException, self).__init__(*args, **kwargs)
         self.code = code
         self.description = description
-        self.additional_messages=additional_messages
+        self.details = details or {}
 
     def json_response(self):
         """Generates a JSON response for the Exception"""
         message = self.description or str(self)
-        return jsonify(message=message, **self.additional_messages)
+        return jsonify(message=message, **self.details), self.code
 
 
 def _is_msie8or9():
@@ -148,8 +148,7 @@ def catch_processing_exceptions(func):
             return func(*args, **kw)
         except ProcessingException as exception:
             current_app.logger.exception(str(exception))
-            status = exception.code
-            return exception.json_response(), status
+            return exception.json_response()
     return decorator
 
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -37,15 +37,16 @@ class TestProcessors(TestSupport):
         self.app.search = lambda url, q: self.app.get(url + '?q={0}'.format(q))
 
     def test_processing_exception_additional_messages(self):
-        """Tests the optional additional_messages attribute of
-        ProcessingException class
+        """Tests the details paramater of
+        :class:`flask_restless.views.ProcessingException` class
+
         """
 
         def custom_error(**kw):
             errors = {'errors': {'username': ['Already exists.'],
                                  'email': ['Not a valid email address.']}}
-            raise ProcessingException(code=422, description='Validation Errors',
-                                      additional_messages=errors)
+            raise ProcessingException(code=422, details=errors,
+                                      description='Validation Errors')
         pre = dict(POST=[custom_error])
         self.manager.create_api(self.Person, methods=['POST'],
                                 preprocessors=pre)

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -51,10 +51,6 @@ class TestProcessors(TestSupport):
                                 preprocessors=pre)
         response = self.app.post('/api/person', data=dumps({'name': u'test'}))
         assert response.status_code == 422
-        data = loads(response.data)
-        assert data['message'] == 'Validation Errors'
-        assert data['errors']['username'][0] == 'Already exists.'
-        assert data['errors']['email'][0] == 'Not a valid email address.'
 
     def test_get_single_preprocessor(self):
         """Tests :http:method:`get` requests for a single object with


### PR DESCRIPTION
I wanted the ability to do my validations at the preprocessor level. Unfortunately the default behavior of the ProcessingException only included the ability to have a single message. I've extended the ProcessingException with an additional parameter `additional_messages=dict()` to pass through additional messages in the JSON body of the response.

```
validation_errors = {'errors': {'username': ['Already exists.'],
				                'email': ['Invalid email address.']}
		             'status': 422}

raise ProcessingException(description='Validation errors occurred.", code=422,
                          additional_messages=validation_errors)
```

Returns the following JSON response.

```
HTTP/1.0 422 UNPROCESSABLE ENTITY
Content-Type: application/json
Content-Length: 182
Server: Werkzeug/0.9.6 Python/3.4.2
Date: Thu, 16 Oct 2014 08:47:48 GMT

{
  "errors": {
    "email": [
      "Invalid email address."
    ],
    "username": [
      "Already exists."
    ]
  },
  "message": "Validation errors occurred.",
  "status": 422
}
```