### PR TITLE
Fixed issue #362 - Unhandled HTTP Exceptions returning HTML instead of JSON

### DIFF
--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -14,7 +14,8 @@
 from collections import defaultdict
 
 from flask import Blueprint
-
+from werkzeug.exceptions import default_exceptions
+from .views import http_exception_json_response
 from .views import API
 from .views import FunctionAPI
 
@@ -194,6 +195,7 @@ class APIManager(object):
         self.session = session or getattr(flask_sqlalchemy_db, 'session', None)
         self.universal_preprocessors = preprocessors or {}
         self.universal_postprocessors = postprocessors or {}
+
 
     def create_api_blueprint(self, model, methods=READONLY_METHODS,
                              url_prefix='/api', collection_name=None,
@@ -490,3 +492,8 @@ class APIManager(object):
         """
         blueprint = self.create_api_blueprint(*args, **kw)
         self.app.register_blueprint(blueprint)
+        # override bulit in default exception handler to convert unhandled
+        # exceptions from html responses to json responses instead
+        for code in default_exceptions.keys():
+            self.app.error_handler_spec[None][code] = \
+                http_exception_json_response

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -146,6 +146,31 @@ def catch_processing_exceptions(func):
     return decorator
 
 
+def http_exception_json_response(ex):
+    """ Convert werkzeug http exceptions into a JSON response.
+
+    `ex` is an Exception raised by `werkzueg.exceptions`.
+
+    By default werkzueg exceptions are returned in HTML format. This can
+    pose a problem for RestFul api's since the client will be expecting
+    JSON formatted responses. Werkzueg exceptions are catched by assigning
+    this function to `flask.Flask.error_handler_spec` with a list of error
+    codes. As a result all unhandled http exceptions will be converted
+    into a JSON format.
+
+    See http://flask.pocoo.org/docs/0.10/api/#flask.Flask.error_handler_spec
+    for more details.
+    """
+    response = jsonify(message=str(ex))
+    if isinstance(ex, HTTPException):
+        for header in ex.get_response().headers:
+            if header[0] == 'Allow':
+                response.headers['Allow'] = header[1]
+    response.status_code = (ex.code if isinstance(ex, HTTPException) else 500)
+    current_app.logger.exception(str(ex))
+    return response
+
+
 def set_headers(response, headers):
     """Sets the specified headers on the specified response.
 

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -146,31 +146,6 @@ def catch_processing_exceptions(func):
     return decorator
 
 
-def http_exception_json_response(ex):
-    """ Convert werkzeug http exceptions into a JSON response.
-
-    `ex` is an Exception raised by `werkzueg.exceptions`.
-
-    By default werkzueg exceptions are returned in HTML format. This can
-    pose a problem for RestFul api's since the client will be expecting
-    JSON formatted responses. Werkzueg exceptions are catched by assigning
-    this function to `flask.Flask.error_handler_spec` with a list of error
-    codes. As a result all unhandled http exceptions will be converted
-    into a JSON format.
-
-    See http://flask.pocoo.org/docs/0.10/api/#flask.Flask.error_handler_spec
-    for more details.
-    """
-    response = jsonify(message=str(ex))
-    if isinstance(ex, HTTPException):
-        for header in ex.get_response().headers:
-            if header[0] == 'Allow':
-                response.headers['Allow'] = header[1]
-    response.status_code = (ex.code if isinstance(ex, HTTPException) else 500)
-    current_app.logger.exception(str(ex))
-    return response
-
-
 def set_headers(response, headers):
     """Sets the specified headers on the specified response.
 


### PR DESCRIPTION
I have implemented a fix that forces all unhandled exceptions to be converted into a JSON response. Previously the framework was returning unwanted HTML responses which could potentially break RESTful clients expecting a JSON formatted response.

```
HTTP/1.0 404 NOT FOUND
Content-Type: text/html
Content-Length: 233
Server: Werkzeug/0.9.6 Python/3.4.2
Date: Fri, 17 Oct 2014 17:20:57 GMT

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>404 Not Found</title>
<h1>Not Found</h1>
<p>The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again.</p>
```

```
HTTP/1.0 405 METHOD NOT ALLOWED
Content-Type: text/html
Allow: POST, OPTIONS
Content-Length: 178
Server: Werkzeug/0.9.6 Python/3.4.2
Date: Fri, 17 Oct 2014 17:23:01 GMT

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>405 Method Not Allowed</title>
<h1>Method Not Allowed</h1>
<p>The method is not allowed for the requested URL.</p>
```

After this fix now all exceptions are returned in JSON format as shown below.

```
HTTP/1.0 404 NOT FOUND
Content-Type: application/json
Content-Length: 33
Server: Werkzeug/0.9.6 Python/3.4.2
Date: Fri, 17 Oct 2014 17:25:43 GMT

{
  "message": "404: Not Found"
}
```

```
HTTP/1.0 405 METHOD NOT ALLOWED
Content-Type: application/json
Content-Length: 42
Allow: OPTIONS, POST
Server: Werkzeug/0.9.6 Python/3.4.2
Date: Fri, 17 Oct 2014 17:25:01 GMT

{
  "message": "405: Method Not Allowed"
}
```