### PR TITLE
Add python 2 and python 3 classifiers in the setup.py file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,12 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Database :: Front-Ends',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules'


### PR DESCRIPTION
`Flask-Restless` is incorrectly considered not compatible with python 3 by several tools like `caniusepython3.com` : https://caniusepython3.com/project/Flask-Restless

I added the correct classifiers in the `setup.py` file as described here : https://docs.python.org/3/howto/pyporting.html#before-you-begin
