### PR TITLE
Resolve datetime strings to datetime objects as required by model.

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -555,7 +555,11 @@ def strings_to_dates(model, dictionary):
             elif value in CURRENT_TIME_MARKERS:
                 result[fieldname] = getattr(func, value.lower())()
             else:
-                result[fieldname] = parse_datetime(value)
+                fieldtype = get_field_type(model, fieldname)
+                if isinstance(fieldtype, Date):
+                    result[fieldname] = parse_datetime(value).date()
+                else:
+                    result[fieldname] = parse_datetime(value)
         elif (is_interval_field(model, fieldname) and value is not None
               and isinstance(value, int)):
             result[fieldname] = datetime.timedelta(seconds=value)

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -42,6 +42,8 @@ from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.query import Query
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.ext.associationproxy import AssociationProxy
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import HTTPException
 from werkzeug.urls import url_quote_plus
@@ -62,6 +64,7 @@ from .helpers import session_query
 from .helpers import strings_to_dates
 from .helpers import to_dict
 from .helpers import upper_keys
+from .helpers import get_related_association_proxy_model
 from .search import create_query
 from .search import search
 
@@ -1057,6 +1060,31 @@ class API(ModelView):
 
         for preprocessor in self.preprocessors['GET_MANY']:
             preprocessor(search_params=search_params)
+
+        # resolve date-strings as required by the model
+        for param in search_params.get('filters', list()):
+            if 'name' in param and 'val' in param:
+                query_model = self.model
+                query_field = param['name']
+
+                if '__' in param['name']:
+                    fieldname, relation = param['name'].split('__')
+                    submodel = getattr(self.model, fieldname)
+                    if isinstance(submodel, InstrumentedAttribute):
+                        query_model = submodel.property.mapper.class_
+                        query_field = relation
+                    elif isinstance(submodel, AssociationProxy):
+                        query_model = get_related_association_proxy_model(submodel)
+                        query_field = relation
+                try:
+                    result = strings_to_dates(
+                        query_model,
+                        {query_field: param['val']}
+                    )
+                    param['val'] = result.get(query_field)
+                except ValueError as exception:
+                    current_app.logger.exception(str(exception))
+                    return dict(message='Unable to construct query'), 400
 
         # perform a filtered search
         try:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1846,6 +1846,36 @@ class TestSearch(TestSupportPrefilled):
         assert resp.status_code == 400
         assert loads(resp.data)['message'] == 'Multiple results found'
 
+    def test_search_dates(self):
+        """Test date parsing"""
+        # Lincoln has been allocated a birthday of 1900-01-02.
+        # We'll ask for dates in a variety of formats, including invalid ones.
+        search = {
+            'single': True,
+            'filters': [{'name': 'birth_date', 'op': 'eq'}]
+        }
+
+        # 1900-01-02
+        search['filters'][0]['val'] = '1900-01-02'
+        resp = self.app.search('/api/person', dumps(search))
+        assert loads(resp.data)['name'] == u'Lincoln'
+
+        # 2nd Jan 1900
+        search['filters'][0]['val'] = '2nd Jan 1900'
+        resp = self.app.search('/api/person', dumps(search))
+        assert loads(resp.data)['name'] == u'Lincoln'
+
+        # Invalid Date
+        search['filters'][0]['val'] = 'REALLY-BAD-DATE'
+        resp = self.app.search('/api/person', dumps(search))
+        assert resp.status_code == 400
+
+        # DateTime
+        # This will be cropped to a date, since birth_date is a Date column
+        search['filters'][0]['val'] = '2nd Jan 1900 14:35'
+        resp = self.app.search('/api/person', dumps(search))
+        assert loads(resp.data)['name'] == u'Lincoln'
+
     def test_search_disjunction(self):
         """Tests for search with disjunctive filters."""
         data = dict(filters=[dict(name='age', op='le', val=10),


### PR DESCRIPTION
I noticed that when you did when searching, the date search terms would just get forwarded to the database without any attempt at checking their validity-- so something like:

    /api/computer?q={"filters":[{"name":"purchase_time", "op":"le", "val":"really-bad-date"}]}

Would just get forwarded on to the database, which means that your query values need to match your database's date/time representations.  And at least in the case of sqlite, you'll get results returned for that query mentioned above, which I don't believe should be expected.  

I noticed that you use dateutil.parser to handle the date-strings resolution using the `string_to_dates`, so I adjusted the query handling code to use that existing function to attempt to resolve a date when indicated by the model.

If you now pass a bad date in, the use will get an `{"message": "Unable to construct query"}` which should be more useful in helping them figure out they've got an error.

In addition, because it's now using dateutil parsing on those params, it allows you to run date queries in a number of formats and get the expected results, eg:

     /api/computer?q={"filters":[{"name":"purchase_time", "op":"le", "val":"2015-01-10T10:49:41.493Z"}]}
     /api/computer?q={"filters":[{"name":"purchase_time", "op":"le", "val":"Sat 10th Jan 2015"}]}
     /api/computer?q={"filters":[{"name":"purchase_time", "op":"le", "val":"Sat, 10 Jan 2015 10:49:41 -0300"}]}