### PR TITLE
Allow include methods on properties

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -330,9 +330,13 @@ def to_dict(instance, deep=None, exclude=None, include=None,
                   if not (col.startswith('__') or col in COLUMN_BLACKLIST))
     # add any included methods
     if include_methods is not None:
-        result.update(dict((method, getattr(instance, method)())
-                           for method in include_methods
-                           if not '.' in method))
+        for method in include_methods:
+            if not '.' in method:
+                value = getattr(instance, method)
+                # Allow properties and static attributes in include_methods
+                if callable(value):
+                    value = value()
+                result[method] = value
     # Check for objects in the dictionary that may not be serializable by
     # default. Convert datetime objects to ISO 8601 format, convert UUID
     # objects to hexadecimal strings, etc.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -252,6 +252,10 @@ class TestSupport(DatabaseTestBase):
             def speed(self):
                 return 42
 
+            @property
+            def speed_property(self):
+                return self.speed()
+
         class Screen(self.Base):
             __tablename__ = 'screen'
             id = Column(Integer, primary_key=True)
@@ -290,7 +294,6 @@ class TestSupport(DatabaseTestBase):
             @is_above_21.expression
             def is_above_21(cls):
                 return select([cls.age > 21]).as_scalar()
-
 
             def name_and_age(self):
                 return "{0} (aged {1:d})".format(self.name, self.age)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -336,6 +336,10 @@ class TestAPIManager(TestSupport):
         self.manager.create_api(self.Computer, url_prefix='/included',
                                 include_methods=['owner.name_and_age'])
 
+        # included non-callable property
+        self.manager.create_api(self.Computer, url_prefix='/included_property',
+                                 include_methods=['speed_property'])
+
         # create a test person
         date = datetime.date(1999, 12, 31)
         person = self.Person(name=u'Test', age=10, other=20, birth_date=date)
@@ -366,6 +370,11 @@ class TestAPIManager(TestSupport):
         response = self.app.get('/included/person')
         response_data = loads(response.data)
         assert response_data['objects'][0]['computers'][0]['speed'] == 42
+
+        # get one with included property
+        response = self.app.get('/included_property/computer/{0}'.format(computer.id))
+        response_data = loads(response.data)
+        assert response_data['speed_property'] == 42
 
     def test_included_method_returns_object(self):
         """Tests that objects are serialized when returned from a method listed


### PR DESCRIPTION
Implementing enhancement #385. `include_methods` now works on non-callable properties.