### PR TITLE
Makes init_app() no longer store a Flask app

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,8 @@ Version 0.16.0-dev
 
 Not yet released.
 
+- #313, #389: :meth:`APIManager.init_app` now can be correctly used to
+  initialize multiple Flask applications.
 - #327, #391: allows ordering searches by fields on related instances.
 - #365: allows preprocessors to specify return values on :http:method:`get`
   requests.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -39,8 +39,8 @@ from sqlalchemy.orm.collections import column_mapped_collection as col_mapped
 from flask.ext.restless.helpers import to_dict
 from flask.ext.restless.manager import APIManager
 
-from .helpers import DatabaseTestBase
 from .helpers import FlaskTestBase
+from .helpers import ManagerTestBase
 from .helpers import skip_unless
 from .helpers import TestSupport
 from .helpers import TestSupportPrefilled
@@ -1879,7 +1879,7 @@ class TestSearch(TestSupportPrefilled):
         assert resp.status_code == 400
 
 
-class TestAssociationProxy(DatabaseTestBase):
+class TestAssociationProxy(ManagerTestBase):
     """Unit tests for models which have a relationship involving an association
     proxy.
 


### PR DESCRIPTION
Before, the APIManager.init_app() method would store the Flask
application provided to it as `self.app`. This violates the rules for
approved Flask extensions, as it makes it impossible to initialize
multiple Flask applications in parallel.

This also fixes an issue with providing a session or Flask-SQLAlchemy
database object in the constructor of APIManager, and later initializing
the Flask application.

This fixes issues #313 and #389.