### PR TITLE
Fix response HTTP code for PATCH many in docs

### DIFF
--- a/docs/requestformat.rst
+++ b/docs/requestformat.rst
@@ -351,7 +351,7 @@ Also suppose we have registered an API for these models at ``/api/person`` and
 
    .. sourcecode:: http
 
-      HTTP/1.1 201 Created
+      HTTP/1.1 200 OK
 
       {"num_modified": 3}
 


### PR DESCRIPTION
The returned code on a successful 'PATCH_MANY' query is 200, not 201.