### PR TITLE
Refactored APIManager to decouple blueprint creation from app instances

### DIFF
--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -14,6 +14,7 @@
 """
 from collections import defaultdict
 from collections import namedtuple
+from uuid import uuid1
 
 from flask import Blueprint
 
@@ -48,9 +49,7 @@ class APIManager(object):
     a given :class:`~flask.Flask` application object.
 
     The :class:`~flask.Flask` object can be specified in the constructor, or
-    after instantiation time by calling the :meth:`init_app` method. In any
-    case, the application object must be specified before calling the
-    :meth:`create_api` method.
+    after instantiation time by calling the :meth:`init_app` method.
 
     `app` is the :class:`flask.Flask` object containing the user's Flask
     application.
@@ -95,111 +94,19 @@ class APIManager(object):
     #: formatting.
     APINAME_FORMAT = '{0}api'
 
-    #: The format of the name of the blueprint containing the API view for a
-    #: given model.
-    #:
-    #: This format string expects the following to be provided when formatting:
-    #:
-    #: 1. name of the API view of a specific model
-    #: 2. a number representing the number of times a blueprint with that name
-    #:    has been registered.
-    BLUEPRINTNAME_FORMAT = '{0}{1}'
-
-    def __init__(self, app=None, **kw):
-        self.app = app
-
-        #: Dictionary mapping Flask application objects to a list of (args, kw)
-        #: pairs for which API creation has been delayed, as when calling
-        #: :meth:`create_api` before calling :meth:`init_app`.
-        self.apis_to_create = defaultdict(list)
-
-        self.flask_sqlalchemy_db = kw.pop('flask_sqlalchemy_db', None)
-        self.session = kw.pop('session', None)
-        if self.app is not None:
-            self.init_app(self.app, **kw)
-
-    @staticmethod
-    def _next_blueprint_name(blueprints, basename):
-        """Returns the next name for a blueprint with the specified base name.
-
-        This method returns a string of the form ``'{0}{1}'.format(basename,
-        number)``, where ``number`` is the next non-negative integer not
-        already used in the name of an existing blueprint.
-
-        For example, if `basename` is ``'personapi'`` and blueprints already
-        exist with names ``'personapi0'``, ``'personapi1'``, and
-        ``'personapi2'``, then this function would return ``'personapi3'``. We
-        expect that code which calls this function will subsequently register a
-        blueprint with that name, but that is not necessary.
-
-        `blueprints` is the list of blueprint names that already exist, as read
-        from :attr:`Flask.blueprints` (that attribute is really a dictionary,
-        but we simply iterate over the keys, which are names of the
-        blueprints).
-
-        """
-        # blueprints is a dict whose keys are the names of the blueprints
-        existing = [name for name in blueprints if name.startswith(basename)]
-        # if this is the first one...
-        if not existing:
-            next_number = 0
-        else:
-            # for brevity
-            b = basename
-            existing_numbers = [int(n.partition(b)[-1]) for n in existing]
-            next_number = max(existing_numbers) + 1
-        return APIManager.BLUEPRINTNAME_FORMAT.format(basename, next_number)
-
-    def init_app(self, app, session=None, flask_sqlalchemy_db=None,
+    def __init__(self, app=None, session=None, flask_sqlalchemy_db=None,
                  preprocessors=None, postprocessors=None):
-        """Stores the specified :class:`flask.Flask` application object on
-        which API endpoints will be registered and the
-        :class:`sqlalchemy.orm.session.Session` object in which all database
-        changes will be made.
+        """Stores the :class:`sqlalchemy.orm.session.Session` object in
+        which all database changes will be made.
 
         `session` is the :class:`sqlalchemy.orm.session.Session` object in
         which changes to the database will be made.
 
         `flask_sqlalchemy_db` is the :class:`flask.ext.sqlalchemy.SQLAlchemy`
-        object with which `app` has been registered and which contains the
-        database models for which API endpoints will be created.
+        object which contains the database models for which API endpoints
+        will be created.
 
         If `flask_sqlalchemy_db` is not ``None``, `session` will be ignored.
-
-        This is for use in the situation in which this class must be
-        instantiated before the :class:`~flask.Flask` application has been
-        created.
-
-        To use this method with pure SQLAlchemy, for example::
-
-            from flask import Flask
-            from flask.ext.restless import APIManager
-            from sqlalchemy import create_engine
-            from sqlalchemy.orm.session import sessionmaker
-
-            apimanager = APIManager()
-
-            # later...
-
-            engine = create_engine('sqlite:////tmp/mydb.sqlite')
-            Session = sessionmaker(bind=engine)
-            mysession = Session()
-            app = Flask(__name__)
-            apimanager.init_app(app, session=mysession)
-
-        and with models defined with Flask-SQLAlchemy::
-
-            from flask import Flask
-            from flask.ext.restless import APIManager
-            from flask.ext.sqlalchemy import SQLAlchemy
-
-            apimanager = APIManager()
-
-            # later...
-
-            app = Flask(__name__)
-            db = SQLALchemy(app)
-            apimanager.init_app(app, flask_sqlalchemy_db=db)
 
         `postprocessors` and `preprocessors` must be dictionaries as described
         in the section :ref:`processors`. These preprocessors and
@@ -212,17 +119,75 @@ class APIManager(object):
         :meth:`create_api_blueprint` method). For more information on using
         preprocessors and postprocessors, see :ref:`processors`.
 
+        This is for use in the situation in which this class must be
+        instantiated before the :class:`~flask.Flask` application has been
+        created.
+        """
+        self.app = app
+
+        #: List of blueprints created by :meth:`create_api` to be registered
+        #: to the app when calling :meth:`init_app`.
+        self.apis_to_create = []
+
+        if flask_sqlalchemy_db is not None:
+            try:
+                session = flask_sqlalchemy_db.session
+            except AttributeError:
+                pass
+            finally:
+                if session is None:
+                    raise ValueError('Flask-Restless requires a valid flask_sqlalchemy_db or session')
+
+        self.restless_info = RestlessInfo(session, preprocessors or {}, postprocessors or {})
+
+        if self.app is not None:
+            self.init_app(self.app)
+
+    def init_app(self, app):
+        """Stores the specified :class:`flask.Flask` application object on
+        which API endpoints will be registered and the
+        :class:`sqlalchemy.orm.session.Session` object in which all database
+        changes will be made.
+
+        This is for use in the situation in which this class must be
+        instantiated before the :class:`~flask.Flask` application has been
+        created.
+
+        To use this method with pure SQLAlchemy, for example::
+
+            from flask import Flask
+            from flask.ext.restless import APIManager
+            from sqlalchemy import create_engine
+            from sqlalchemy.orm.session import sessionmaker
+
+            engine = create_engine('sqlite:////tmp/mydb.sqlite')
+            Session = sessionmaker(bind=engine)
+            mysession = Session()
+            apimanager = APIManager(session=mysession)
+
+            # later...
+            app = Flask(__name__)
+            apimanager.init_app(app)
+
+        and with models defined with Flask-SQLAlchemy::
+
+            from flask import Flask
+            from flask.ext.restless import APIManager
+            from flask.ext.sqlalchemy import SQLAlchemy
+
+            db = SQLALchemy(app)
+            apimanager = APIManager(flask_sqlalchemy_db=db)
+
+            # later...
+
+            app = Flask(__name__)
+            apimanager.init_app(app)
+
         .. versionadded:: 0.13.0
            Added the `preprocessors` and `postprocessors` keyword arguments.
 
         """
-        # If the SQLAlchemy database was provided in the constructor, use that.
-        if flask_sqlalchemy_db is None:
-            flask_sqlalchemy_db = self.flask_sqlalchemy_db
-        # If the session was provided in the constructor, use that.
-        if session is None:
-            session = self.session
-        session = session or getattr(flask_sqlalchemy_db, 'session', None)
+
         # Use the `extensions` dictionary on the provided Flask object to store
         # extension-specific information.
         if not hasattr(app, 'extensions'):
@@ -230,25 +195,14 @@ class APIManager(object):
         if 'restless' in app.extensions:
             raise ValueError('Flask-Restless has already been initialized on'
                              ' this application: {0}'.format(app))
-        app.extensions['restless'] = RestlessInfo(session,
-                                                  preprocessors or {},
-                                                  postprocessors or {})
-        # Now that this application has been initialized, create blueprints for
-        # which API creation was deferred in :meth:`create_api`. This includes
-        # all (args, kw) pairs for the key in :attr:`apis_to_create`
-        # corresponding to ``app``, as well as any (args, kw) pairs
-        # corresponding to the ``None`` key, which represents a call to
-        # :meth:`create_api` that is just waiting for any Flask application to
-        # be initialized.
-        #
-        # Rename apis_to_create for the sake of brevity
-        apis = self.apis_to_create
-        to_create = apis.pop(app, []) + apis.pop(None, [])
-        for args, kw in to_create:
-            blueprint = self.create_api_blueprint(app=app, *args, **kw)
+
+        app.extensions['restless'] = self.restless_info
+        # Now that this application has been initialized, register all
+        # the queued blueprints
+        for blueprint in self.apis_to_create:
             app.register_blueprint(blueprint)
 
-    def create_api_blueprint(self, model, app=None, methods=READONLY_METHODS,
+    def create_api_blueprint(self, name, model, methods=READONLY_METHODS,
                              url_prefix='/api', collection_name=None,
                              allow_patch_many=False, allow_delete_many=False,
                              allow_functions=False, exclude_columns=None,
@@ -454,11 +408,6 @@ class APIManager(object):
             msg = ('Cannot simultaneously specify both include columns and'
                    ' exclude columns.')
             raise IllegalArgumentError(msg)
-        # If no Flask application is specified, use the one (we assume) was
-        # specified in the constructor.
-        if app is None:
-            app = self.app
-        restlessinfo = app.extensions['restless']
         if collection_name is None:
             collection_name = model.__tablename__
         # convert all method names to upper case
@@ -482,27 +431,23 @@ class APIManager(object):
         postprocessors_ = defaultdict(list)
         preprocessors_.update(preprocessors or {})
         postprocessors_.update(postprocessors or {})
-        for key, value in restlessinfo.universal_preprocessors.items():
+        for key, value in self.restless_info.universal_preprocessors.items():
             preprocessors_[key] = value + preprocessors_[key]
-        for key, value in restlessinfo.universal_postprocessors.items():
+        for key, value in self.restless_info.universal_postprocessors.items():
             postprocessors_[key] = value + postprocessors_[key]
         # the view function for the API for this model
-        api_view = API.as_view(apiname, restlessinfo.session, model,
+        api_view = API.as_view(apiname, self.restless_info.session, model,
                                exclude_columns, include_columns,
                                include_methods, validation_exceptions,
                                results_per_page, max_results_per_page,
                                post_form_preprocessor, preprocessors_,
                                postprocessors_, primary_key)
-        # suffix an integer to apiname according to already existing blueprints
-        blueprintname = APIManager._next_blueprint_name(app.blueprints,
-                                                        apiname)
         # add the URL rules to the blueprint: the first is for methods on the
         # collection only, the second is for methods which may or may not
         # specify an instance, the third is for methods which must specify an
         # instance
         # TODO what should the second argument here be?
-        # TODO should the url_prefix be specified here or in register_blueprint
-        blueprint = Blueprint(blueprintname, __name__, url_prefix=url_prefix)
+        blueprint = Blueprint(name, __name__, url_prefix=url_prefix)
         # For example, /api/person.
         blueprint.add_url_rule(collection_endpoint,
                                methods=no_instance_methods, view_func=api_view)
@@ -539,7 +484,7 @@ class APIManager(object):
         if allow_functions:
             eval_api_name = apiname + 'eval'
             eval_api_view = FunctionAPI.as_view(eval_api_name,
-                                                restlessinfo.session, model)
+                                                self.restless_info.session, model)
             eval_endpoint = '/eval' + collection_endpoint
             blueprint.add_url_rule(eval_endpoint, methods=['GET'],
                                    view_func=eval_api_view)
@@ -563,41 +508,12 @@ class APIManager(object):
            :meth:`create_api_blueprint`; the registration remains here.
 
         """
-        # Check if the user is providing a specific Flask application with
-        # which the model's API will be associated.
-        if 'app' in kw:
-            # If an application object was already provided in the constructor,
-            # raise an error indicating that the user is being confusing.
-            if self.app is not None:
-                msg = ('Cannot provide a Flask application in the APIManager'
-                       ' constructor and in create_api(); must choose exactly'
-                       ' one')
-                raise IllegalArgumentError(msg)
-            app = kw.pop('app')
-            # If the Flask application has already been initialized, then
-            # immediately create the API blueprint.
-            #
-            # TODO This is something of a fragile check for whether or not
-            # init_app() has been called on kw['app'], since some other
-            # (malicious) code could simply add the key 'restless' to the
-            # extensions dictionary.
-            if 'restless' in app.extensions:
-                blueprint = self.create_api_blueprint(app=app, *args, **kw)
-                app.register_blueprint(blueprint)
-            # If the Flask application has not yet been initialized, then stash
-            # the positional and keyword arguments for later initialization.
-            else:
-                self.apis_to_create[app].append((args, kw))
-        # The user did not provide a Flask application here.
+
+        blueprint = self.create_api_blueprint(uuid1(), *args, **kw)
+
+        if self.app is not None:
+            self.app.register_blueprint(blueprint)
+        # If no Flask application was provided in the constructor,
+        # then queue blueprint for later registration.
         else:
-            # If a Flask application object was already provided in the
-            # constructor, immediately create the API blueprint.
-            if self.app is not None:
-                app = self.app
-                blueprint = self.create_api_blueprint(app=app, *args, **kw)
-                app.register_blueprint(blueprint)
-            # If no Flask application was provided in the constructor either,
-            # then stash the positional and keyword arguments for later
-            # initalization.
-            else:
-                self.apis_to_create[None].append((args, kw))
+            self.apis_to_create.append(blueprint)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -63,30 +63,31 @@ class TestLocalAPIManager(DatabaseTestBase):
         :class:`flask.ext.restless.APIManager` object.
 
         """
-        manager = APIManager()
-        manager.init_app(self.flaskapp, session=self.session)
-        manager.create_api(self.Person, app=self.flaskapp)
+        manager = APIManager(session=self.session)
+        manager.create_api(self.Person)
+        manager.init_app(self.flaskapp)
         response = self.app.get('/api/person')
         assert response.status_code == 200
 
     def test_init_app_split_initialization(self):
         manager = APIManager(session=self.session)
+        manager.create_api(self.Person)
         manager.init_app(self.flaskapp)
-        manager.create_api(self.Person, app=self.flaskapp)
         response = self.app.get('/api/person')
         assert response.status_code == 200
 
     def test_init_multiple(self):
-        manager = APIManager(session=self.session)
+        manager1 = APIManager(session=self.session)
+        manager2 = APIManager(session=self.session)
         flaskapp1 = self.flaskapp
         flaskapp2 = Flask(__name__)
         testclient1 = self.app
         testclient2 = flaskapp2.test_client()
         force_json_contenttype(testclient2)
-        manager.init_app(flaskapp1)
-        manager.init_app(flaskapp2)
-        manager.create_api(self.Person, app=flaskapp1)
-        manager.create_api(self.Computer, app=flaskapp2)
+        manager1.create_api(self.Person)
+        manager2.create_api(self.Computer)
+        manager1.init_app(flaskapp1)
+        manager2.init_app(flaskapp2)
         response = testclient1.get('/api/person')
         assert response.status_code == 200
         response = testclient1.get('/api/computer')
@@ -98,14 +99,15 @@ class TestLocalAPIManager(DatabaseTestBase):
 
     def test_creation_api_without_app_dependency(self):
         """Tests that api can be added before app will be passed to manager."""
-        manager = APIManager()
+        manager = APIManager(session=self.session)
         manager.create_api(self.Person)
-        manager.init_app(self.flaskapp, self.session)
+        manager.init_app(self.flaskapp)
         response = self.app.get('/api/person')
         assert response.status_code == 200
 
     def test_multiple_app_delayed_init(self):
-        manager = APIManager(session=self.session)
+        manager1 = APIManager(session=self.session)
+        manager2 = APIManager(session=self.session)
 
         # Create the Flask applications and the test clients.
         flaskapp1 = self.flaskapp
@@ -115,10 +117,10 @@ class TestLocalAPIManager(DatabaseTestBase):
         force_json_contenttype(testclient2)
 
         # First create the API, then initialize the Flask applications after.
-        manager.create_api(self.Person, app=flaskapp1)
-        manager.create_api(self.Computer, app=flaskapp2)
-        manager.init_app(flaskapp1)
-        manager.init_app(flaskapp2)
+        manager1.create_api(self.Person)
+        manager2.create_api(self.Computer)
+        manager1.init_app(flaskapp1)
+        manager2.init_app(flaskapp2)
 
         # Tests that only the first Flask application gets requests for
         # /api/person and only the second gets requests for /api/computer.
@@ -769,15 +771,8 @@ class TestFSA(FlaskTestBase):
         assert loads(response.data)['objects'][0]['name'] == 'bar'
 
     def test_init_app(self):
-        manager = APIManager()
-        manager.init_app(self.flaskapp, flask_sqlalchemy_db=self.db)
-        manager.create_api(self.Person, app=self.flaskapp)
-        response = self.app.get('/api/person')
-        assert response.status_code == 200
-
-    def test_init_app_split_initialization(self):
         manager = APIManager(flask_sqlalchemy_db=self.db)
+        manager.create_api(self.Person)
         manager.init_app(self.flaskapp)
-        manager.create_api(self.Person, app=self.flaskapp)
         response = self.app.get('/api/person')
         assert response.status_code == 200


### PR DESCRIPTION
Changed the extension initialization following the suggestions in jfinkels/flask-restless#397.

All global parameters are passed to the APIManager constructor.

The init_app method now accepts only one argument: the app instance.

If the app instance is not supplied to the constructor, the create_api method must be called *before* calling init_app, since init_app will register the blueprints created by create_api. If the constructor is supplied with an app instance, this tells the extension that the user is not interested in using multiple applications (as per Flask specs), the app instance is stored and create_api can be used any time after APIManager has been instantiated.

Creating blueprints using create_api_blueprint now requires a mandatory name argument.
Blueprint names are generated using uuid1 by create_api method.