### PR TITLE
Don't allow excluding primary key from POST

### DIFF
--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -20,6 +20,8 @@ from flask import Blueprint
 from .views import API
 from .views import FunctionAPI
 
+from .helpers import primary_key_name
+
 #: The set of methods which are allowed by default when creating an API
 READONLY_METHODS = frozenset(('GET', ))
 
@@ -472,6 +474,15 @@ class APIManager(object):
             possibly_empty_instance_methods |= frozenset(('PATCH', 'PUT'))
         if allow_delete_many and 'DELETE' in methods:
             possibly_empty_instance_methods |= frozenset(('DELETE', ))
+
+        # Check that primary_key is included for no_instance_methods
+        if no_instance_methods:
+            pk_name = primary_key or primary_key_name(model)
+            if (include_columns and pk_name not in include_columns or
+                exclude_columns and pk_name in exclude_columns):
+                msg = ('The primary key must be included for APIs with POST.')
+                raise IllegalArgumentError(msg)
+
         # the base URL of the endpoints on which requests will be made
         collection_endpoint = '/{0}'.format(collection_name)
         # the name of the API, for use in creating the view and the blueprint

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -11,6 +11,8 @@
 """
 import datetime
 
+from nose.tools import raises
+
 from flask import Flask
 from flask import json
 try:
@@ -24,6 +26,7 @@ from sqlalchemy import Integer
 
 from flask.ext.restless import APIManager
 from flask.ext.restless.helpers import get_columns
+from flask.ext.restless.manager import IllegalArgumentError
 
 from .helpers import DatabaseTestBase
 from .helpers import FlaskTestBase
@@ -561,6 +564,15 @@ class TestAPIManager(TestSupport):
         response = self.app.get('/none/person/{0}'.format(personid))
         for column in 'name', 'age', 'other', 'birth_date', 'computers':
             assert column not in loads(response.data)
+
+    @raises(IllegalArgumentError)
+    def test_exclude_primary_key_column(self):
+        """Tests that trying to create a writable API while excluding the
+        primary key field raises an error.
+
+        """
+        self.manager.create_api(self.Person, exclude_columns=['id'],
+                                methods=['POST'], url_prefix='/exclude_pk')
 
     def test_different_urls(self):
         """Tests that establishing different URL endpoints for the same model


### PR DESCRIPTION
After an hour of diving into the code this is the best I could come up with.

I'm not sure if this is actually the right spot to check for these kind of things.
Maybe change the wording of the error and also add a note to the docs on this behavior.