### PR TITLE
Fix includes end excludes for subresources

### DIFF
--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -356,7 +356,17 @@ def to_dict(instance, deep=None, exclude=None, include=None,
             result[key] = to_dict(value)
     # recursively call _to_dict on each of the `deep` relations
     deep = deep or {}
+
     for relation, rdeep in deep.items():
+        if (
+            (exclude and relation in exclude)
+            or (exclude_relations and relation in exclude_relations)
+            or (include and relation not in include)
+            or (include_methods and relation not in include_methods)
+            or (include_relations and relation not in include_relations)
+        ):
+            continue
+
         # Get the related value so we can see if it is None, a list, a query
         # (as specified by a dynamic relationship loader), or an actual
         # instance of a model.

--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -357,13 +357,17 @@ def to_dict(instance, deep=None, exclude=None, include=None,
     # recursively call _to_dict on each of the `deep` relations
     deep = deep or {}
 
+    all_excludes = exclude or []
+    all_excludes.extend(list(exclude_relations) if exclude_relations else [])
+
+    all_includes = include or []
+    all_includes.extend(list(include_methods) if include_methods else [])
+    all_includes.extend(list(include_relations) if include_relations else [])
+
     for relation, rdeep in deep.items():
         if (
-            (exclude and relation in exclude)
-            or (exclude_relations and relation in exclude_relations)
-            or (include and relation not in include)
-            or (include_methods and relation not in include_methods)
-            or (include_relations and relation not in include_relations)
+            (all_excludes and relation in all_excludes)
+            or (all_includes and relation not in all_includes)
         ):
             continue
 

--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -605,18 +605,13 @@ def count(session, query):
     queries.
 
     """
-    counts = query.selectable.with_only_columns([func.count()])
-    num_results = session.execute(counts.order_by(None))
+    # counts = query.selectable.with_only_columns([func.count()])
+    # num_results = session.execute(counts.order_by(None)).scalar()
 
-    if num_results.rowcount > 1:
-        # Workaround for LEFT OUTER JOIN combined with GROUP BY and ORDER BY
-        num_results = sum(map(operator.itemgetter(0), num_results))
-    else:
-        num_results = num_results.scalar()
-
-    if num_results is None or query._limit:
-        return query.count()
-    return num_results
+    # if num_results is None or query._limit:
+    #     return query.count()
+    # return num_results
+    return query.count()
 
 
 # This code comes from <http://stackoverflow.com/a/6798042/108197>, which is

--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -131,6 +131,8 @@ class APIManager(object):
         #: the corresponding collection names for those models.
         self.created_apis_for = {}
 
+        self._created_apis = {}
+
         # Stash this instance so that it can be examined later by other
         # functions in this module.
         url_for.created_managers.append(self)
@@ -590,7 +592,7 @@ class APIManager(object):
                                results_per_page, max_results_per_page,
                                post_form_preprocessor, preprocessors_,
                                postprocessors_, primary_key, serializer,
-                               deserializer)
+                               deserializer, manager=self)
         # suffix an integer to apiname according to already existing blueprints
         blueprintname = APIManager._next_blueprint_name(app.blueprints,
                                                         apiname)

--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -331,7 +331,8 @@ class APIManager(object):
                              max_results_per_page=100,
                              post_form_preprocessor=None, preprocessors=None,
                              postprocessors=None, primary_key=None,
-                             serializer=None, deserializer=None):
+                             serializer=None, deserializer=None,
+                             view_class=None):
         """Creates and returns a ReSTful API interface as a blueprint, but does
         not register it on any :class:`flask.Flask` application.
 
@@ -586,13 +587,14 @@ class APIManager(object):
         for key, value in restlessinfo.universal_postprocessors.items():
             postprocessors_[key] = value + postprocessors_[key]
         # the view function for the API for this model
-        api_view = API.as_view(apiname, restlessinfo.session, model,
-                               exclude_columns, include_columns,
-                               include_methods, validation_exceptions,
-                               results_per_page, max_results_per_page,
-                               post_form_preprocessor, preprocessors_,
-                               postprocessors_, primary_key, serializer,
-                               deserializer, manager=self)
+        view_class = view_class or API
+        api_view = view_class.as_view(
+            apiname, restlessinfo.session, model, exclude_columns,
+            include_columns, include_methods, validation_exceptions,
+            results_per_page, max_results_per_page, post_form_preprocessor,
+            preprocessors_, postprocessors_, primary_key, serializer,
+            deserializer, manager=self,
+        )
         # suffix an integer to apiname according to already existing blueprints
         blueprintname = APIManager._next_blueprint_name(app.blueprints,
                                                         apiname)

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1235,8 +1235,8 @@ class API(ModelView):
         result[_HEADERS] = headers
         return result, 200, headers
 
-    def _seek_results(self, params):
-        return search(self.session, self.model, params)
+    def _seek_results(self, params, *args, **kwargs):
+        return search(self.session, self.model, params, *args, **kwargs)
 
     def get(self, instid, relationname, relationinstid):
         """Returns a JSON representation of an instance of model with the

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -661,6 +661,9 @@ class API(ModelView):
            `authentication_function` keyword arguments.
 
         """
+        self.manager = kw.pop('manager')
+        self.manager._created_apis[model] = self
+
         super(API, self).__init__(session, model, *args, **kw)
         if exclude_columns is None:
             self.exclude_columns, self.exclude_relations = (None, None)
@@ -973,14 +976,25 @@ class API(ModelView):
             start = 0
             end = num_results
             total_pages = 1
-        objects = [to_dict(x, deep, exclude=self.exclude_columns,
-                           exclude_relations=self.exclude_relations,
-                           include=self.include_columns,
-                           include_relations=self.include_relations,
-                           include_methods=self.include_methods)
-                   for x in instances[start:end]]
-        return dict(page=page_num, objects=objects, total_pages=total_pages,
-                    num_results=num_results)
+
+        objects = []
+        apis = self.manager._created_apis
+
+        for x in instances[start:end]:
+            api = apis[x.__class__]
+            objects.append(to_dict(x, deep,
+                           exclude=api.exclude_columns,
+                           exclude_relations=api.exclude_relations,
+                           include=api.include_columns,
+                           include_relations=api.include_relations,
+                           include_methods=api.include_methods))
+
+        return {
+            'page': page_num,
+            'objects': objects,
+            'total_pages': total_pages,
+            'num_results': num_results,
+        }
 
     def _inst_to_dict(self, inst):
         """Returns the dictionary representation of the specified instance.
@@ -1262,6 +1276,7 @@ class API(ModelView):
             related_model = get_related_model(self.model, relationname)
             relations = frozenset(get_relations(related_model))
             deep = dict((r, {}) for r in relations)
+
             if relationinstid is not None:
                 related_value_instance = get_by(self.session, related_model,
                                                 relationinstid)
@@ -1598,3 +1613,36 @@ class API(ModelView):
     def put(self, *args, **kw):
         """Alias for :meth:`patch`."""
         return self.patch(*args, **kw)
+
+    @classmethod
+    def as_view(cls, name, *class_args, **class_kwargs):
+        """Converts the class into an actual view function that can be used
+        with the routing system.  Internally this generates a function on the
+        fly which will instantiate the :class:`View` on each request and call
+        the :meth:`dispatch_request` method on it.
+
+        The arguments passed to :meth:`as_view` are forwarded to the
+        constructor of the class.
+        """
+        self = cls(*class_args, **class_kwargs)
+
+        def view(*args, **kwargs):
+            return self.dispatch_request(*args, **kwargs)
+
+        if cls.decorators:
+            view.__name__ = name
+            view.__module__ = cls.__module__
+            for decorator in cls.decorators:
+                view = decorator(view)
+
+        # we attach the view class to the view function for two reasons:
+        # first of all it allows us to easily figure out what class-based
+        # view this thing came from, secondly it's also used for instantiating
+        # the view class so you can actually replace it with something else
+        # for testing purposes and debugging.
+        view.view_class = cls
+        view.__name__ = name
+        view.__doc__ = cls.__doc__
+        view.__module__ = cls.__module__
+        view.methods = cls.methods
+        return view

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -24,7 +24,7 @@
 """
 from __future__ import division
 
-from collections import defaultdict
+from collections import defaultdict, Iterable
 from functools import wraps
 import math
 import warnings
@@ -1183,7 +1183,7 @@ class API(ModelView):
 
         # perform a filtered search
         try:
-            result = search(self.session, self.model, search_params)
+            result = self._seek_results(search_params)
         except NoResultFound:
             return dict(message='No result found'), 404
         except MultipleResultsFound:
@@ -1204,7 +1204,7 @@ class API(ModelView):
         deep = dict((r, {}) for r in relations)
 
         # for security purposes, don't transmit list as top-level JSON
-        if isinstance(result, Query):
+        if isinstance(result, Query) or isinstance(result, Iterable):
             result = self._paginated(result, deep)
             # Create the Link header.
             #
@@ -1234,6 +1234,9 @@ class API(ModelView):
         # for more information.
         result[_HEADERS] = headers
         return result, 200, headers
+
+    def _seek_results(self, params):
+        return search(self.session, self.model, params)
 
     def get(self, instid, relationname, relationinstid):
         """Returns a JSON representation of an instance of model with the


### PR DESCRIPTION
Hello!

I have experienced same problem as described at #211.

That issue tells that if we have API like `/resource/<:id>/subresource` then all fields of `subresource` are exposed. It seems like includes and excludes which were defined for `subresource` are not applied.

 However, the problem is more complicated. Actually, what we have is that includes and excludes of `resource` are applied for `subresource`. This is a terrible issue, because `to_dict` can try to include fields/methods/relations which are not defines for `subresource`. And this will just result into HTTP 500.

This patch resolves the issue. I'm not sure this is done in a perfect way, so we can make a discussion if needed.