### PR TITLE
Use linkage objects for relationships

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1355,8 +1355,10 @@ class API(APIBase):
                 if not self.allow_to_many_replacement:
                     message = 'Not allowed to replace a to-many relationship'
                     return error_response(403, detail=message)
-                newvalue = {}
+                # If this is left empty, the relationship will be zeroed.
+                newvalue = []
                 notfound = []
+
                 for rel in linkage:
                     # TODO check for conflicting or missing types here
                     # type_ = link['type']
@@ -1364,15 +1366,14 @@ class API(APIBase):
                     if inst is None:
                         notfound.append((rel['id'], rel['type']))
                     else:
-                        newvalue[inst] = dict((k, v) for k, v in rel.items()
-                                              if k not in ('type', 'id'))
+                        newvalue.append(inst)
                     # If the to-one relationship resource or any of the to-many
                     # relationship resources do not exist, return an error
                     # response.
                     if notfound:
                         msg = 'No object of type {0} found with ID {1}'
                         errors = [error(detail=msg.format(type_, id_))
-                                  for type_, id_ in not_found]
+                                  for type_, id_ in notfound]
                         return errors_response(404, errors)
             # Otherwise, it is a to-one relationship, so just get the single
             # related resource.
@@ -1386,8 +1387,7 @@ class API(APIBase):
                     detail = ('No object of type {0} found'
                               ' with ID {1}').format(linkage['type'], link['id'])
                     return error_response(404, detail=detail)
-                newvalue = {inst: dict((k, v) for k, v in rel.items()
-                                       if k not in ('type', 'id'))}
+                newvalue = inst
             # Set the new value of the relationship.
             try:
                 # TODO Here if there are any extra attributes in

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -1598,15 +1598,17 @@ class TestUpdatingResources(ManagerTestBase):
         self.session.add_all([person1, person2, article])
         self.session.commit()
         # Change the author of the article from person 1 to person 2.
-        data = {'data':
-                    {'type': 'article',
-                     'id': '1',
-                     'links':
-                         {'author':
-                              {'type': 'person', 'id': '2'}
-                          }
-                     }
+        data = {
+            'data': {
+                'type': 'article',
+                'id': '1',
+                'links': {
+                    'author': {
+                        'linkage': {'type': 'person', 'id': '2'}
+                    }
                 }
+            }
+        }
         response = self.app.patch('/api/article/1', data=dumps(data))
         assert response.status_code == 204
         assert article.author is person2
@@ -1626,13 +1628,13 @@ class TestUpdatingResources(ManagerTestBase):
         self.session.add_all([person, article])
         self.session.commit()
         # Change the author of the article to None.
-        data = {'data':
-                    {'type': 'article',
-                     'id': '1',
-                     'links':
-                         {'author': None}
-                     }
-                }
+        data = {
+            'data': {
+                'type': 'article',
+                'id': '1',
+                'links': {'author': {'linkage': None}}
+            }
+        }
         response = self.app.patch('/api/article/1', data=dumps(data))
         assert response.status_code == 204
         assert article.author is None
@@ -1654,15 +1656,20 @@ class TestUpdatingResources(ManagerTestBase):
         self.manager.create_api(self.Person, methods=['PATCH'],
                                 url_prefix='/api2',
                                 allow_to_many_replacement=True)
-        data = {'data':
-                    {'type': 'person',
-                     'id': '1',
-                     'links':
-                         {'articles': [{'type': 'article', 'id': '1'},
-                                       {'type': 'article', 'id': '2'}]
-                          }
-                     }
+        data = {
+            'data': {
+                'type': 'person',
+                'id': '1',
+                'links': {
+                    'articles': {
+                        'linkage': [
+                            {'type': 'article', 'id': '1'},
+                            {'type': 'article', 'id': '2'}
+                        ]
+                    }
                 }
+            }
+        }
         response = self.app.patch('/api2/person/1', data=dumps(data))
         assert response.status_code == 204
         assert set(person.articles) == {article1, article2}
@@ -1685,12 +1692,17 @@ class TestUpdatingResources(ManagerTestBase):
         self.manager.create_api(self.Person, methods=['PATCH'],
                                 url_prefix='/api2',
                                 allow_to_many_replacement=True)
-        data = {'data':
-                    {'type': 'person',
-                     'id': '1',
-                     'links': {'articles': []}
-                     }
+        data = {
+            'data': {
+                'type': 'person',
+                'id': '1',
+                'links': {
+                    'articles': {
+                        'linkage': []
+                    }
                 }
+            }
+        }
         response = self.app.patch('/api2/person/1', data=dumps(data))
         assert response.status_code == 204
         assert person.articles == []
@@ -1709,12 +1721,13 @@ class TestUpdatingResources(ManagerTestBase):
         person = self.Person(id=1)
         self.session.add(person)
         self.session.commit()
-        data = {'data':
-                    {'type': 'person',
-                     'id': '1',
-                     'links': {'articles': []}
-                     }
-                }
+        data = {
+            'data': {
+                'type': 'person',
+                'id': '1',
+                'links': {'articles': {'linkage': []}}
+            }
+        }
         response = self.app.patch('/api/person/1', data=dumps(data))
         assert response.status_code == 403
 
@@ -1772,12 +1785,15 @@ class TestUpdatingResources(ManagerTestBase):
         self.manager.create_api(self.Person, methods=['PATCH'],
                                 url_prefix='/api2',
                                 allow_to_many_replacement=True)
-        data = {'data':
-                    {'type': 'person',
-                     'id': '1',
-                     'links': {'articles': [{'type': 'article', 'id': '1'}]}
-                     }
+        data = {
+            'data': {
+                'type': 'person',
+                'id': '1',
+                'links': {
+                    'articles': {'linkage': [{'type': 'article', 'id': '1'}]}
                 }
+            }
+        }
         response = self.app.patch('/api2/person/1', data=dumps(data))
         assert response.status_code == 404
         # TODO test for error details

--- a/tests/test_updating.py
+++ b/tests/test_updating.py
@@ -663,16 +663,20 @@ class TestAssociationProxy(ManagerTestBase):
         self.manager.create_api(self.Article, methods=['PATCH'],
                                 url_prefix='/api2',
                                 allow_to_many_replacement=True)
-        data = {'data':
-                    {'type': 'article',
-                     'id': '1',
-                     'links':
-                         {'tags':
-                              [{'type': 'tag', 'id': '1'},
-                               {'type': 'tag', 'id': '2'}]
-                          }
-                     }
+        data = {
+            'data': {
+                'type': 'article',
+                'id': '1',
+                'links': {
+                    'tags': {
+                        'linkage': [
+                            {'type': 'tag', 'id': '1'},
+                            {'type': 'tag', 'id': '2'}
+                        ]
+                    }
                 }
+            }
+        }
         response = self.app.patch('/api2/article/1', data=dumps(data))
         assert response.status_code == 204
         assert [tag1, tag2] == sorted(article.tags, key=lambda t: t.id)
@@ -713,14 +717,17 @@ class TestAssociationProxy(ManagerTestBase):
         self.manager.create_api(self.Article, methods=['PATCH'],
                                 url_prefix='/api2',
                                 allow_to_many_replacement=True)
-        data = {'data':
-                    {'type': 'article',
-                     'id': '1',
-                     'links':
-                         {'tags':
-                              [{'type': 'tag', 'id': '1', 'extrainfo': 'foo'}]}
-                     }
+        data = {
+            'data': {
+                'type': 'article',
+                'id': '1',
+                'links': {
+                    'tags': {
+                        'linkage': [{'type': 'tag', 'id': '1', 'extrainfo': 'foo'}]
+                    }
                 }
+            }
+        }
         response = self.app.patch('/api2/article/1', data=dumps(data))
         assert response.status_code == 204
         assert article.tags == [tag]


### PR DESCRIPTION
Updating relationships now uses linkage objects, as the latest JSON API [requires](http://jsonapi.org/format/#crud-updating-resource-relationships) and as discussed in #404.

I ended up with a bit of yak shaving along the way, and updated the input for the tests in `test_jsonapi.py` as well. I don't _think_ I broke anything else.

Regarding `test_updating.TestAssociationProxy.test_extra_info`, I'm not entirely sure what this is supposed to do. Shouldn't intermediate data basically be handled as being its own resource? I can't find any mention of intermediate data in the spec, unless I missed something, which is entirely possible.

In addition, I ended up having to eliminate the [dictionary passing](https://github.com/jfinkels/flask-restless/blob/jsonapi/flask_restless/views.py#L1362) that was done and pass a list instead. I couldn't figure out what the dictionary was supposed to do and it created some trouble. If they are meant to update the related objects somehow, can't that be done by instead filling a list and manipulating the objects directly?

Anyway, that was a good start. Happy to take a look at some of the other m2m/association proxy stuff, but I need to know what actually needs doing first :smile: 