### PR TITLE
Add deserialization support for Time columns

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -352,6 +352,8 @@ class TestSupport(ManagerTestBase):
             __tablename__ = 'satellite'
             name = Column(Unicode, primary_key=True)
             period = Column(Interval, nullable=True)
+            launch_date = Column(Date, nullable=True)
+            launch_time = Column(Time(timezone=True), nullable=True)
 
         class Star(self.Base):
             __tablename__ = 'star'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,6 +11,8 @@
 """
 from datetime import date
 from datetime import datetime
+from datetime import time
+from dateutil.tz import tzoffset
 import uuid
 
 from nose.tools import assert_raises
@@ -135,6 +137,27 @@ class TestModelHelpers(TestSupport):
         d = to_dict(computer)
         assert 'buy_date' in d
         assert d['buy_date'] == computer.buy_date.isoformat()
+
+    def test_time_serialization(self):
+        """Tests that time objects in the database are correctly serialized
+        in the :func:`flask.ext.restless.helpers.to_dict` function.
+        """
+        user = self.User(wakeup=time(8, 15, 0, 0))
+        self.session.commit()
+        d = to_dict(user)
+        assert 'wakeup' in d
+        assert d['wakeup'] == user.wakeup.isoformat()
+
+    def test_time_tz_serialization(self):
+        """Tests that time objects with a timezone in the database are correctly
+        serialized in the :func:`flask.ext.restless.helpers.to_dict` function.
+        """
+        satellite = self.Satellite(
+            launch_time=time(12, 30, 0, 0, tzoffset('GFT', -3*60*60)))
+        self.session.commit()
+        d = to_dict(satellite)
+        assert 'launch_time' in d
+        assert d['launch_time'] == satellite.launch_time.isoformat()
 
     def test_uuid(self):
         """Tests for correct serialization of UUID objects."""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -13,6 +13,7 @@
 """
 from datetime import date
 from datetime import datetime
+from datetime import time
 from datetime import timedelta
 import math
 # In Python 2, the function is `urllib.quote()`, in Python 3 it is
@@ -473,6 +474,20 @@ class TestAPI(TestSupport):
         assert response.status_code == 200
         data = loads(response.data)
         assert data['wakeup'] == now.isoformat()
+
+    def test_post_time_functions(self):
+        self.manager.create_api(
+            self.User, primary_key='id', methods=['GET', 'POST'])
+        orig_wakeup = time(8, 45, 0, 0)
+        data = dict(id=1, email='foo', wakeup=orig_wakeup.isoformat())
+        response = self.app.post('/api/user', data=dumps(data))
+        assert response.status_code == 201
+        response = self.app.get('/api/user/1')
+        assert response.status_code == 200
+        wakeup = loads(response.data)['wakeup']
+        assert wakeup is not None
+        wakeup = dateutil.parser.parse(wakeup).timetz()
+        assert wakeup == orig_wakeup
 
     def test_post_interval_functions(self):
         oldJSONEncoder = self.flaskapp.json_encoder


### PR DESCRIPTION
Adds functionality for converting from a time string in a JSON request to a datetime.time object to use with SQLAlchemy Time columns. Time columns with time zones are supported. Testing for columns with time zones are not fully covered as SQLite does not support time zones. Serialization was already supported so this change only covers deserialization.