### PR TITLE
Infer collection_name from __table__

### DIFF
--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -548,7 +548,7 @@ class APIManager(object):
             app = self.app
         restlessinfo = app.extensions['restless']
         if collection_name is None:
-            collection_name = model.__tablename__
+            collection_name = model.__table__.name
         # convert all method names to upper case
         methods = frozenset((m.upper() for m in methods))
         # sets of methods used for different types of endpoints


### PR DESCRIPTION
Model classes that have been defined in a declarative style are not guaranteed to have a `__tablename__` attribute.  For example, if they have been declared in a hybrid style with an embedded table:

    class example(base):
        __table__ = Table(...)

However even those declared just via a `__tablename_` will have a `__table__` attribute (created by the metaclass), so to infer the collection name in all cases we should use `__table__.name`.