### PR TITLE
fixed issue #455: type of toremove not being checked in _remove_from_relation 

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -807,6 +807,8 @@ class API(ModelView):
 
         """
         submodel = get_related_model(self.model, relationname)
+        if isinstance(toremove, dict):
+            toremove = [toremove]
         for dictionary in toremove or []:
             remove = dictionary.pop('__delete__', False)
             if 'id' in dictionary:


### PR DESCRIPTION
It's identical to the check in _add_to_relation.  Basically, if send in something like (below) an attributeerror gets thrown since you're iterating over the elements of a dict rather than dict-elements of a list.

```
{
    {"members":
        {"remove":
            {"id": 1}
         }
     }
}

