### PR TITLE
Marshmallow serializer post_dump

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1456,7 +1456,7 @@ class API(ModelView):
         # Determine the value of the primary key for this instance and
         # encode URL-encode it (in case it is a Unicode string).
         pk_name = self.primary_key or primary_key_name(instance)
-        primary_key = result[pk_name]
+        primary_key = getattr(instance, pk_name)
         try:
             primary_key = str(primary_key)
         except UnicodeEncodeError:


### PR DESCRIPTION
When using marshmallow's @post_dump decorator to wrap json response in an object node.  
Then the Primary key attribute is not available on `result` and should rather be collected from the `instance` itself.

http://marshmallow.readthedocs.org/en/latest/extending.html#example-enveloping-revisited

```
# Example outputs
{
    'user': {
        'id': 123,
        'name': 'Keith',
        'email': 'keith@stones.com'
    }
}
```
