### PR TITLE
Alias relations in search order.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build/
 dist/
 *egg*/
 docs/_build
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist/
 *egg*/
 docs/_build
 venv/
+/*.egg

--- a/flask_restless/search.py
+++ b/flask_restless/search.py
@@ -19,6 +19,7 @@ import inspect
 from sqlalchemy import and_
 from sqlalchemy import or_
 from sqlalchemy.ext.associationproxy import AssociationProxy
+from sqlalchemy.orm import aliased
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from .helpers import session_query
@@ -492,7 +493,7 @@ class QueryBuilder(object):
                         field_name, field_name_in_relation = \
                             field_name.split('__')
                         relation = getattr(model, field_name)
-                        relation_model = relation.mapper.class_
+                        relation_model = aliased(relation.mapper.class_)
                         field = getattr(relation_model, field_name_in_relation)
                         direction = getattr(field, val.direction)
                         query = query.join(relation_model)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -104,18 +104,21 @@ def unregister_fsa_session_signals():
     if not flask_sa:
         return
 
-    if event.contains(SessionBase, 'before_commit',
-                      flask_sa._SessionSignalEvents.session_signal_before_commit):
-        event.remove(SessionBase, 'before_commit',
-                     flask_sa._SessionSignalEvents.session_signal_before_commit)
-    if event.contains(SessionBase, 'after_commit',
-                      flask_sa._SessionSignalEvents.session_signal_after_commit):
-        event.remove(SessionBase, 'after_commit',
-                     flask_sa._SessionSignalEvents.session_signal_after_commit)
-    if event.contains(SessionBase, 'after_rollback',
-                      flask_sa._SessionSignalEvents.session_signal_after_rollback):
-        event.remove(SessionBase, 'after_rollback',
-                     flask_sa._SessionSignalEvents.session_signal_after_rollback)
+    try:
+        if event.contains(SessionBase, 'before_commit',
+                          flask_sa._SessionSignalEvents.session_signal_before_commit):
+            event.remove(SessionBase, 'before_commit',
+                         flask_sa._SessionSignalEvents.session_signal_before_commit)
+        if event.contains(SessionBase, 'after_commit',
+                          flask_sa._SessionSignalEvents.session_signal_after_commit):
+            event.remove(SessionBase, 'after_commit',
+                         flask_sa._SessionSignalEvents.session_signal_after_commit)
+        if event.contains(SessionBase, 'after_rollback',
+                          flask_sa._SessionSignalEvents.session_signal_after_rollback):
+            event.remove(SessionBase, 'after_rollback',
+                         flask_sa._SessionSignalEvents.session_signal_after_rollback)
+    except AttributeError:
+        pass
 
 
 def force_json_contenttype(test_client):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -104,12 +104,18 @@ def unregister_fsa_session_signals():
     if not flask_sa:
         return
 
-    event.remove(SessionBase, 'before_commit',
-                 flask_sa._SessionSignalEvents.session_signal_before_commit)
-    event.remove(SessionBase, 'after_commit',
-                 flask_sa._SessionSignalEvents.session_signal_after_commit)
-    event.remove(SessionBase, 'after_rollback',
-                 flask_sa._SessionSignalEvents.session_signal_after_rollback)
+    if event.contains(SessionBase, 'before_commit',
+                      flask_sa._SessionSignalEvents.session_signal_before_commit):
+        event.remove(SessionBase, 'before_commit',
+                     flask_sa._SessionSignalEvents.session_signal_before_commit)
+    if event.contains(SessionBase, 'after_commit',
+                      flask_sa._SessionSignalEvents.session_signal_after_commit):
+        event.remove(SessionBase, 'after_commit',
+                     flask_sa._SessionSignalEvents.session_signal_after_commit)
+    if event.contains(SessionBase, 'after_rollback',
+                      flask_sa._SessionSignalEvents.session_signal_after_rollback):
+        event.remove(SessionBase, 'after_rollback',
+                     flask_sa._SessionSignalEvents.session_signal_after_rollback)
 
 
 def force_json_contenttype(test_client):


### PR DESCRIPTION
The function sqlalchemy.orm.aliased() creates an aliased version of a model for use in joins, ie "JOIN foo ON foo.id = bar.foo_id" is replaced by "JOIN foo AS foo1 ON foo1.id = bar.foo_id". Aliasing every join in search order is the easiest way of making sure that there is no conflict between two orders on the same model.

This patch fixes the unit test broken on master, `tests.test_search.TestQueryCreation.test_order_by_two_different_fields_of_the_same_relation`