### PR TITLE
#458 Use the new primary key if it was patched

### DIFF
--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1589,6 +1589,8 @@ class API(ModelView):
                 postprocessor(query=query, result=result,
                               search_params=search_params)
         else:
+            if self.primary_key in data:
+                instid = data[self.primary_key]
             result = self._instid_to_dict(instid)
             for postprocessor in self.postprocessors['PATCH_SINGLE']:
                 postprocessor(result=result)

--- a/flask_restless/views.py
+++ b/flask_restless/views.py
@@ -1589,8 +1589,10 @@ class API(ModelView):
                 postprocessor(query=query, result=result,
                               search_params=search_params)
         else:
-            if self.primary_key in data:
-                instid = data[self.primary_key]
+            instance = self.deserialize(data)
+            pk_name = self.primary_key or primary_key_name(instance)
+            if pk_name in data:
+                instid = data[pk_name]
             result = self._instid_to_dict(instid)
             for postprocessor in self.postprocessors['PATCH_SINGLE']:
                 postprocessor(result=result)


### PR DESCRIPTION
Can't test whether this breaks anything, since the current set of tests do not pass 100% before this change. I can't see why it would be incorrect.