### PR TITLE
Only remove the events if they have actually been listened.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -104,18 +104,21 @@ def unregister_fsa_session_signals():
     if not flask_sa:
         return
 
-    if event.contains(SessionBase, 'before_commit',
-                      flask_sa._SessionSignalEvents.session_signal_before_commit):
-        event.remove(SessionBase, 'before_commit',
-                     flask_sa._SessionSignalEvents.session_signal_before_commit)
-    if event.contains(SessionBase, 'after_commit',
-                      flask_sa._SessionSignalEvents.session_signal_after_commit):
-        event.remove(SessionBase, 'after_commit',
-                     flask_sa._SessionSignalEvents.session_signal_after_commit)
-    if event.contains(SessionBase, 'after_rollback',
-                      flask_sa._SessionSignalEvents.session_signal_after_rollback):
-        event.remove(SessionBase, 'after_rollback',
-                     flask_sa._SessionSignalEvents.session_signal_after_rollback)
+    try:
+        if event.contains(SessionBase, 'before_commit',
+                          flask_sa._SessionSignalEvents.session_signal_before_commit):
+            event.remove(SessionBase, 'before_commit',
+                         flask_sa._SessionSignalEvents.session_signal_before_commit)
+        if event.contains(SessionBase, 'after_commit',
+                          flask_sa._SessionSignalEvents.session_signal_after_commit):
+            event.remove(SessionBase, 'after_commit',
+                         flask_sa._SessionSignalEvents.session_signal_after_commit)
+        if event.contains(SessionBase, 'after_rollback',
+                          flask_sa._SessionSignalEvents.session_signal_after_rollback):
+            event.remove(SessionBase, 'after_rollback',
+                         flask_sa._SessionSignalEvents.session_signal_after_rollback)
+    except AttributeError:
+        pass
 
 
 def force_json_contenttype(test_client):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -104,12 +104,18 @@ def unregister_fsa_session_signals():
     if not flask_sa:
         return
 
-    event.remove(SessionBase, 'before_commit',
-                 flask_sa._SessionSignalEvents.session_signal_before_commit)
-    event.remove(SessionBase, 'after_commit',
-                 flask_sa._SessionSignalEvents.session_signal_after_commit)
-    event.remove(SessionBase, 'after_rollback',
-                 flask_sa._SessionSignalEvents.session_signal_after_rollback)
+    if event.contains(SessionBase, 'before_commit',
+                      flask_sa._SessionSignalEvents.session_signal_before_commit):
+        event.remove(SessionBase, 'before_commit',
+                     flask_sa._SessionSignalEvents.session_signal_before_commit)
+    if event.contains(SessionBase, 'after_commit',
+                      flask_sa._SessionSignalEvents.session_signal_after_commit):
+        event.remove(SessionBase, 'after_commit',
+                     flask_sa._SessionSignalEvents.session_signal_after_commit)
+    if event.contains(SessionBase, 'after_rollback',
+                      flask_sa._SessionSignalEvents.session_signal_after_rollback):
+        event.remove(SessionBase, 'after_rollback',
+                     flask_sa._SessionSignalEvents.session_signal_after_rollback)
 
 
 def force_json_contenttype(test_client):


### PR DESCRIPTION
These lines were put in place to fix a bug with Flask-SQLAlchemy adding listeners in a way which causes problems for a pure SQLAlchemy session. It seems that this is fixed in version 2.0 of Flask-SQLAlchemy, and the fix is now a bug. Adding the condition with "contains" means that this should now work on both older and newer version of Flask-SA (although it is untested on older versions).

An example of the test failure with the previous version and flask-sqlalchemy 2.1:

```
======================================================================
ERROR: tests.test_views.TestFSAModel.test_get
Test for the :meth:`views.API.get` method with models defined using
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jack/c/flask-restless/venv/local/lib/python2.7/site-packages/nose/case.py", line 384, in tearDown
    try_run(self.inst, ('teardown', 'tearDown'))
  File "/home/jack/c/flask-restless/venv/local/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/jack/c/flask-restless/tests/helpers.py", line 87, in inner
    return test(*args, **kw)
  File "/home/jack/c/flask-restless/tests/test_views.py", line 112, in tearDown
    unregister_fsa_session_signals()
  File "/home/jack/c/flask-restless/tests/helpers.py", line 108, in unregister_fsa_session_signals
    flask_sa._SessionSignalEvents.session_signal_before_commit)
AttributeError: type object '_SessionSignalEvents' has no attribute 'session_signal_before_commit'

----------------------------------------------------------------------
```