### PR TITLE
Excludes the explicitly excluded relations

### DIFF
--- a/flask_restless/serialization.py
+++ b/flask_restless/serialization.py
@@ -460,6 +460,10 @@ class DefaultSerializer(Serializer):
         # Only consider those relations listed in `only`.
         if only is not None:
             relations = [r for r in relations if r in only]
+        # Exclude relations specified by the user during the instantiation of
+        # this object.
+        if self.exclude is not None:
+            relations = [r for r in relations if r not in self.exclude]
         if not relations:
             return result
         # For the sake of brevity, rename this function.


### PR DESCRIPTION
The documentation online says that we can list relations in the `exclude` parameter, but it looks like they weren't being excluded! Was this done intentionally? If not, here's a tiny fix :smile: 