### PR TITLE
Fixes: Fetching relationships fetches all existing resources

### DIFF
--- a/flask_restless/search.py
+++ b/flask_restless/search.py
@@ -360,7 +360,7 @@ def search_relationship(session, instance, relation, filters=None, sort=None,
     #     primary_keys = {primary_key_value(inst) for inst in relationship}
     #
     primary_keys = set(primary_key_value(inst) for inst in relationship)
-    query.filter(primary_key_value(related_model) in primary_keys)
+    query = query.filter(primary_key_value(related_model).in_(primary_keys))
 
     return search(session, related_model, filters=filters, sort=sort,
                   group_by=group_by, _initial_query=query)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -217,6 +217,7 @@ class TestFiltering(SearchTestBase):
         person = self.Person(id=1)
         article1 = self.Article(id=1)
         article2 = self.Article(id=2)
+        person.articles = [article1, article2]
         self.session.add_all([person, article1, article2])
         self.session.commit()
         filters = [dict(name='id', op='equals', val='1')]

--- a/tests/test_jsonapi/test_fetching_data.py
+++ b/tests/test_jsonapi/test_fetching_data.py
@@ -287,8 +287,9 @@ class TestFetchingData(ManagerTestBase):
         article = self.Article(id=1)
         comment1 = self.Comment(id=1)
         comment2 = self.Comment(id=2)
+        comment3 = self.Comment(id=3)
         article.comments = [comment1, comment2]
-        self.session.add_all([article, comment1, comment2])
+        self.session.add_all([article, comment1, comment2, comment3])
         self.session.commit()
         response = self.app.get('/api/article/1/relationships/comments')
         assert response.status_code == 200

--- a/tests/test_jsonapi/test_fetching_data.py
+++ b/tests/test_jsonapi/test_fetching_data.py
@@ -952,7 +952,7 @@ class TestSorting(ManagerTestBase):
             to_string = unicode
         except NameError:
             to_string = str
-        articles = [self.Article(id=i, title=to_string(i)) for i in range(5)]
+        articles = [self.Article(id=i, title=to_string(i), author=person) for i in range(5)]
         self.session.add(person)
         self.session.add_all(articles)
         self.session.commit()


### PR DESCRIPTION
When trying to fetch relationships via _/resource/<id>/relation_name/_ all existing resources of the relation type are returned. Not only those related to the resource.
I debugged this and I think that I found the potential bug.
The _filter()_ method returns a new query object which was thrown away.
Also, the "in" operator doesn't seem to work on _InstrumentedAttribute_. So I changed it to use the in_() method.