### PR TITLE
Replaces nose with unittest2

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
-unittest2
+nose
 savalidation
+unittest2
 
 # For testing PostgreSQL specific operations...
 testing.postgresql

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-nose
+unittest2
 savalidation
 
 # For testing PostgreSQL specific operations...

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
-nose
 savalidation
 unittest2
 

--- a/setup.py
+++ b/setup.py
@@ -101,8 +101,8 @@ setup(
     name='Flask-Restless',
     platforms='any',
     packages=find_packages(),
-    test_suite='nose.collector',
-    tests_require=['nose'],
+    test_suite='tests',
+    tests_require=['unittest2'],
     url='https://github.com/jfinkels/flask-restless',
     version=find_version('flask_restless', '__init__.py'),
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -101,8 +101,8 @@ setup(
     name='Flask-Restless',
     platforms='any',
     packages=find_packages(),
-    test_suite='tests',
-    tests_require=['unittest2'],
+    test_suite='nose.collector',
+    tests_require=['nose'],
     url='https://github.com/jfinkels/flask-restless',
     version=find_version('flask_restless', '__init__.py'),
     zip_safe=False

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -18,8 +18,8 @@ from functools import wraps
 from json import JSONEncoder
 import sys
 import types
-from unittest import skipUnless as skip_unless
-from unittest import TestCase
+from unittest2 import skipUnless as skip_unless
+from unittest2 import TestCase
 import uuid
 
 from flask import Flask

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -10,7 +10,7 @@
 # License version 3 and under the 3-clause BSD license. For more
 # information, see LICENSE.AGPL and LICENSE.BSD.
 """Unit tests for the JSON API Bulk extension."""
-from unittest import skip
+from unittest2 import skip
 
 from sqlalchemy import Column
 from sqlalchemy import Integer

--- a/tests/test_creating.py
+++ b/tests/test_creating.py
@@ -21,7 +21,7 @@ specification.
 """
 from __future__ import division
 from datetime import datetime
-from unittest import skip
+from unittest2 import skip
 
 import dateutil
 from sqlalchemy import Column

--- a/tests/test_deleting.py
+++ b/tests/test_deleting.py
@@ -18,7 +18,7 @@ Flask-Restless meets the minimum requirements of the JSON API
 specification.
 
 """
-from unittest import skip
+from unittest2 import skip
 
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -19,7 +19,7 @@ specification.
 
 """
 from operator import itemgetter
-from unittest import skip
+from unittest2 import skip
 
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -14,7 +14,7 @@ from datetime import date
 from datetime import datetime
 from datetime import time
 from operator import itemgetter
-from unittest import skip
+from unittest2 import skip
 
 # This import is unused but is required for testing on PyPy. CPython can
 # use psycopg2, but PyPy can only use psycopg2cffi.

--- a/tests/test_jsonapi/test_server_responsibilities.py
+++ b/tests/test_jsonapi/test_server_responsibilities.py
@@ -18,7 +18,7 @@ section of the JSON API specification.
 .. _Server Responsibilities: http://jsonapi.org/format/#content-negotiation-servers
 
 """
-from unittest import skip
+from unittest2 import skip
 
 from sqlalchemy import Column
 from sqlalchemy import Unicode

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -10,7 +10,7 @@
 # License version 3 and under the 3-clause BSD license. For more
 # information, see LICENSE.AGPL and LICENSE.BSD.
 """Unit tests for the :mod:`flask_restless.manager` module."""
-from unittest import skip
+from unittest2 import skip
 
 from flask import Flask
 from sqlalchemy import Column

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,7 +10,7 @@
 # License version 3 and under the 3-clause BSD license. For more
 # information, see LICENSE.AGPL and LICENSE.BSD.
 """Unit tests for metadata in server responses."""
-from unittest import skip
+from unittest2 import skip
 
 from sqlalchemy import Column
 from sqlalchemy import Integer

--- a/tests/test_updating.py
+++ b/tests/test_updating.py
@@ -21,7 +21,7 @@ specification.
 from __future__ import division
 
 from datetime import datetime
-from unittest import skip
+from unittest2 import skip
 
 try:
     from flask.ext.sqlalchemy import SQLAlchemy

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -18,7 +18,7 @@ to test that it captures validation errors and returns them to the
 client.
 
 """
-from unittest import skipUnless as skip_unless
+from unittest2 import skipUnless as skip_unless
 import sys
 
 from sqlalchemy import Column


### PR DESCRIPTION
Commit 4b3cc1b0b122ccc5469a0257d72854623388d0aa, which removes nose-specific code, breaks the build for Python 2.6, since that version of Python doesn't have `unittest.skip()`, for example. Let's import `unittest2` instead and see what happens.

Testers should still be able to use nose, it's just not required anymore.