### PR TITLE
Adds single table inheritance support for models

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,9 +18,12 @@ Version 1.0.0b2-dev
 Not yet released.
 
 - Changes serialization/deserialization to class-based implementation instead
-  of a function-based implementation.
+  of a function-based implementation. This also adds support for serialization
+  of heterogeneous collections.
 - :issue:`7`: allows filtering before function evaluation.
 - :issue:`49`: deserializers now expect a complete JSON API document.
+- :issue:`200`: be smarter about determining the ``collection_name`` for
+  polymorphic tables.
 - :issue:`253`: don't assign to callable attributes of models.
 - :issue:`481,488`: added negation (``not``) operator for search.
 - :issue:`492`: support JSON API recommended "simple" filtering.

--- a/CHANGES
+++ b/CHANGES
@@ -23,11 +23,12 @@ Not yet released.
 - :issue:`7`: allows filtering before function evaluation.
 - :issue:`49`: deserializers now expect a complete JSON API document.
 - :issue:`200`: be smarter about determining the ``collection_name`` for
-  polymorphic tables.
+  polymorphic models defined with single-table inheritance.
 - :issue:`253`: don't assign to callable attributes of models.
 - :issue:`481,488`: added negation (``not``) operator for search.
 - :issue:`492`: support JSON API recommended "simple" filtering.
 - :issue:`508`: flush the session before postprocessors, and commit after.
+- :issue:`536`: adds support for single-table inheritance.
 
 Version 1.0.0b1
 ---------------

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -1,7 +1,3 @@
-.. currentmodule:: flask.ext.restless
-
-.. _basicusage:
-
 Creating API endpoints
 ======================
 
@@ -10,10 +6,11 @@ SQLAlchemy or Flask-SQLALchemy. The basic setup in either case is nearly the
 same.
 
 If you have defined your models with Flask-SQLAlchemy, first, create your
-:class:`~flask.Flask` object, :class:`~flask.ext.sqlalchemy.SQLAlchemy` object,
-and model classes as usual but with one additional restriction: each model must
-have a primary key column named ``id`` of type :class:`sqlalchemy.Integer` or
-type :class:`sqlalchemy.Unicode`.
+:class:`~flask.Flask` object, :class:`~flask_sqlalchemy.SQLAlchemy` object, and
+model classes as usual but with one additional restriction: each model must
+have a primary key column named ``id`` of type
+:class:`~sqlalchemy.sql.sqltypes.Integer` or type
+:class:`~sqlalchemy.sql.sqltypes.Unicode`.
 
 .. sourcecode:: python
 
@@ -67,7 +64,7 @@ If you are using pure SQLAlchemy::
    Base.metadata.create_all()
 
 Second, instantiate an :class:`APIManager` object with the
-:class:`~flask.Flask` and :class:`~flask.ext.sqlalchemy.SQLAlchemy` objects::
+:class:`~flask.Flask` and :class:`~flask_sqlalchemy.SQLAlchemy` objects::
 
     from flask.ext.restless import APIManager
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,7 +261,7 @@ man_pages = [
 intersphinx_mapping = {
     'python': ('http://docs.python.org/', None),
     'flask': ('http://flask.pocoo.org/docs', None),
-    'sqlalchemy': ('http://sqlalchemy.org/docs', None),
+    'sqlalchemy': ('http://docs.sqlalchemy.org/en/latest', None),
     'flasksqlalchemy': ('http://flask-sqlalchemy.pocoo.org', None),
     'flasklogin': ('https://flask-login.readthedocs.org/en/latest', None)
 }

--- a/docs/databasesetup.rst
+++ b/docs/databasesetup.rst
@@ -1,0 +1,219 @@
+Common SQLAlchemy setups
+========================
+
+Flask-Restless automatically handles SQLAlchemy models defined with
+`association proxies`_ and `polymorphism`_.
+
+.. _association proxies: http://docs.sqlalchemy.org/en/latest/orm/extensions/associationproxy.html
+.. _polymorphism: http://docs.sqlalchemy.org/en/latest/orm/inheritance.html
+
+Association proxies
+-------------------
+
+Flask-Restless handles many-to-many relationships transparently through
+association proxies. It exposes the remote table in the ``relationships``
+element of a resource in the JSON document and hides the intermediate table.
+
+For example, consider a setup where there are articles and tags in a
+many-to-many relationship::
+
+    from sqlalchemy import Column, Integer, Unicode, ForeignKey
+    from sqlalchemy.ext.associationproxy import association_proxy
+    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import relationship, backref
+
+    Base = declarative_base()
+
+    class Article(Base):
+        __tablename__ = 'article'
+        id = Column(Integer, primary_key=True)
+        tags = association_proxy('articletags', 'tag')
+
+    class ArticleTag(Base):
+        __tablename__ = 'articletag'
+        article_id = Column(Integer, ForeignKey('article.id'),
+                            primary_key=True)
+        article = relationship(Article, backref=backref('articletags'))
+        tag_id = Column(Integer, ForeignKey('tag.id'), primary_key=True)
+        tag = relationship('Tag')
+
+    class Tag(Base):
+        __tablename__ = 'tag'
+        id = Column(Integer, primary_key=True)
+
+Resource objects of type ``'article'`` will have ``tags`` relationship that
+proxies directly to the ``Tag`` resource through the ``ArticleTag`` table:
+
+.. sourcecode:: json
+
+   {
+     "data": {
+       "id": "1",
+       "type": "article",
+       "relationships": {
+         "tags": {
+           "data": [
+             {
+               "id": "1",
+               "type": "tag"
+             },
+             {
+               "id": "2",
+               "type": "tag"
+             }
+           ],
+         }
+       }
+     }
+   }
+
+By default, the intermediate ``articletags`` relationship does not appear as a
+relationship in the resource object.
+
+
+Polymorphic models
+------------------
+
+Flask-Restless automatically handles polymorphic models. For single-table
+inheritance, we have made some design choices we believe are reasonable.
+Requests to create, update, or delete a resource must specify a ``type`` that
+matches the collection name of the endpoint. This means you cannot request to
+create a resource of the subclass type at the endpoint for the superclass type,
+for example. On the other hand, requests to fetch a collection of objects that
+have a subclass will yield a response that includes all resources of the
+superclass and all resources of any subclass.
+
+For example, consider a setup where there are employees and some employees are
+managers::
+
+    from sqlalchemy import Column, Integer, Enum
+    from sqlalchemy.ext.declarative import declarative_base
+
+    Base = declarative_base()
+
+    class Employee(Base):
+        __tablename__ = 'employee'
+        id = Column(Integer, primary_key=True)
+        type = Column(Enum('employee', 'manager'), nullable=False)
+        __mapper_args__ = {
+            'polymorphic_on': type,
+            'polymorphic_identity': 'employee'
+        }
+
+    class Manager(Employee):
+        __mapper_args__ = {
+            'polymorphic_identity': 'manager'
+        }
+
+Collection name
+...............
+
+When creating an API for these models, Flask-Restless chooses the polymorphic
+identity as the collection name::
+
+    >>> from flask.ext.restless import collection_name
+    >>>
+    >>> manager.create_api(Employee)
+    >>> manager.create_api(Manager)
+    >>> collection_name(Employee)
+    'employee'
+    >>> collection_name(Manager)
+    'manager'
+
+Creating and updating resources
+...............................
+
+Creating a resource require the ``type`` element of the resource object in the
+request to match the collection name of the endpoint::
+
+    >>> from flask import json
+    >>> import requests
+    >>>
+    >>> headers = {
+    ...     'Accept': 'application/vnd.api+json',
+    ...     'Content-Type': 'application/vnd.api+json'
+    ... }
+    >>> resource = {'data': {'type': 'employee'}}
+    >>> data = json.dumps(resource)
+    >>> response = requests.post('https://example.com/api/employee', data=data,
+    ...                           headers=headers)
+    >>> response.status_code
+    201
+    >>> resource = {'data': {'type': 'manager'}}
+    >>> data = json.dumps(resource)
+    >>> response = requests.post('https://example.com/api/manager', data=data,
+    ...                           headers=headers)
+    >>> response.status_code
+    201
+
+If the ``type`` does not match the collection name for the endpoint, the server
+responds with a :http:statuscode:`409`::
+
+    >>> resource = {'data': {'type': 'manager'}}
+    >>> data = json.dumps(resource)
+    >>> response = requests.post('https://example.com/api/employee', data=data,
+    ...                           headers=headers)
+    >>> response.status_code
+    409
+
+The same rules apply for updating resources.
+
+Fetching resources
+..................
+
+Assume the database contains an employee with ID 1 and a manager with ID 2.
+You can only fetch each individual resource at the endpoint for the exact type
+of that resource::
+
+    >>> response = requests.get('https://example.com/api/employee/1')
+    >>> response.status_code
+    200
+    >>> response = requests.get('https://example.com/api/manager/2')
+    >>> response.status_code
+    200
+
+You cannot access individual resources of the subclass at the endpoint for the
+superclass::
+
+    >>> response = requests.get('https://example.com/api/employee/2')
+    >>> response.status_code
+    404
+    >>> response = requests.get('https://example.com/api/manager/1')
+    >>> response.status_code
+    404
+
+Fetching from the superclass endpoint yields a response that includes resources
+of the superclass and resources of the subclass::
+
+    >>> response = requests.get('https://example.com/api/employee')
+    >>> document = json.loads(response.data)
+    >>> resources = document['data']
+    >>> employee, manager = resources
+    >>> employee['type']
+    'employee'
+    >>> employee['id']
+    '1'
+    >>> manager['type']
+    'manager'
+    >>> manager['id']
+    '2'
+
+Deleting resources
+..................
+
+Assume the database contains an employee with ID 1 and a manager with ID 2.
+You can only delete from the endpoint that matches the exact type of the
+resource::
+
+    >>> response = requests.delete('https://example.com/api/employee/2')
+    >>> response.status_code
+    404
+    >>> response = requests.delete('https://example.com/api/manager/1')
+    >>> response.status_code
+    404
+    >>> response = requests.delete('https://example.com/api/employee/1')
+    >>> response.status_code
+    204
+    >>> response = requests.delete('https://example.com/api/manager/2')
+    >>> response.status_code
+    204

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ the JSON API specification.
    basicusage
    requestformat
    customizing
+   databasesetup
 
 API reference
 -------------

--- a/flask_restless/serialization/__init__.py
+++ b/flask_restless/serialization/__init__.py
@@ -16,7 +16,6 @@ from .exceptions import MultipleExceptions
 from .exceptions import SerializationException
 from .serializers import DefaultSerializer
 from .serializers import JsonApiDocument
-from .serializers import simple_heterogeneous_serialize_many
 from .serializers import simple_serialize
 from .serializers import simple_serialize_many
 from .serializers import simple_relationship_serialize

--- a/flask_restless/serialization/serializers.py
+++ b/flask_restless/serialization/serializers.py
@@ -458,41 +458,11 @@ class DefaultSerializer(Serializer):
         return result
 
     def serialize_many(self, instances, only=None):
-        # Here we are assuming the iterable of instances is homogeneous
-        # (i.e. each instance is of the same type).
-        #
-        # Since loading each instance from a given resource object
-        # representation could theoretically raise a
-        # DeserializationException, we collect all the errors and wrap
-        # them in a MultipleExceptions exception object.
-        resources = []
-        failed = []
-        for instance in instances:
-            try:
-                resource = self._dump(instance, only=only)
-                resources.append(resource)
-            except SerializationException as exception:
-                failed.append(exception)
-        if failed:
-            raise MultipleExceptions(failed)
-        result = JsonApiDocument()
-        result['data'] = resources
-        return result
-
-
-class HeterogeneousSerializer(DefaultSerializer):
-    """A serializer for heterogeneous collections of instances (that is,
-    collections in which each instance is of a different type).
-
-    This class overrides the :meth:`DefaultSerializer.serialize_many`
-    method, which currently works only for homogeneous collections, to
-    apply the correct model-specific serializer for each instance (as
-    registered at the time of invoking :meth:`APIManager.create_api`).
-
-    """
-
-    def serialize_many(self, instances, only=None):
         """Serializes each instance using its model-specific serializer.
+
+        This method works for heterogeneous collections of instances
+        (that is, collections in which each instance is of a different
+        type).
 
         The `only` keyword argument must be a dictionary mapping
         resource type name to list of fields representing a sparse
@@ -501,7 +471,7 @@ class HeterogeneousSerializer(DefaultSerializer):
         :meth:`DefaultSerializer.serialize` method.
 
         """
-        result = []
+        resources = []
         failed = []
         for instance in instances:
             # Determine the serializer for this instance.
@@ -530,11 +500,13 @@ class HeterogeneousSerializer(DefaultSerializer):
                 #
                 # TODO We could use `serializer._dump` instead.
                 serialized = serialized['data']
-                result.append(serialized)
+                resources.append(serialized)
             except SerializationException as exception:
                 failed.append(exception)
         if failed:
             raise MultipleExceptions(failed)
+        result = JsonApiDocument()
+        result['data'] = resources
         return result
 
 
@@ -588,8 +560,6 @@ class DefaultRelationshipSerializer(Serializer):
 #: serialization methods.
 singleton_serializer = DefaultSerializer()
 
-singleton_heterogeneous_serializer = HeterogeneousSerializer()
-
 #: This is an instance of the default relationship serializer class,
 #: :class:`DefaultRelationshipSerializer`.
 #:
@@ -612,8 +582,6 @@ simple_serialize = singleton_serializer.serialize
 #: This function is suitable for calling on its own, no other
 #: instantiation or customization necessary.
 simple_serialize_many = singleton_serializer.serialize_many
-
-simple_heterogeneous_serialize_many = singleton_heterogeneous_serializer.serialize_many
 
 simple_relationship_dump = singleton_relationship_serializer._dump
 

--- a/flask_restless/views/resources.py
+++ b/flask_restless/views/resources.py
@@ -22,6 +22,7 @@ from werkzeug.exceptions import BadRequest
 
 from ..helpers import collection_name
 from ..helpers import get_by
+from ..helpers import get_model
 from ..helpers import get_related_model
 from ..helpers import has_field
 from ..helpers import is_like_list
@@ -154,9 +155,19 @@ class API(APIBase):
         # Get the resource with the specified ID.
         primary_resource = get_by(self.session, self.model, resource_id,
                                   self.primary_key)
-        # Return an error if there is no resource with the specified ID.
-        if primary_resource is None:
-            detail = 'No instance with ID {0}'.format(resource_id)
+        # We check here whether there actually is an instance of the
+        # correct type and ID.
+        #
+        # The first condition is True exactly when there is no row in
+        # the table with the given primary key value. The second is True
+        # in the special case when the resource exists but is a subclass
+        # of the actual model for this API; this may happen if the model
+        # is a polymorphic subclass of another class using a single
+        # inheritance table.
+        found_model = get_model(primary_resource)
+        if primary_resource is None or found_model is not self.model:
+            detail = 'no resource of type {0} with ID {1}'
+            detail = detail.format(collection_name(self.model), resource_id)
             return error_response(404, detail=detail)
         # Return an error if the specified relation does not exist on
         # the model.
@@ -238,8 +249,19 @@ class API(APIBase):
         # Get the resource with the specified ID.
         primary_resource = get_by(self.session, self.model, resource_id,
                                   self.primary_key)
-        if primary_resource is None:
-            detail = 'No resource with ID {0}'.format(resource_id)
+        # We check here whether there actually is an instance of the
+        # correct type and ID.
+        #
+        # The first condition is True exactly when there is no row in
+        # the table with the given primary key value. The second is True
+        # in the special case when the resource exists but is a subclass
+        # of the actual model for this API; this may happen if the model
+        # is a polymorphic subclass of another class using a single
+        # inheritance table.
+        found_model = get_model(primary_resource)
+        if primary_resource is None or found_model is not self.model:
+            detail = 'no resource of type {0} with ID {1}'
+            detail = detail.format(collection_name(self.model), resource_id)
             return error_response(404, detail=detail)
         # Return an error if the specified relation does not exist on
         # the model.
@@ -289,8 +311,18 @@ class API(APIBase):
         # Get the resource with the specified ID.
         resource = get_by(self.session, self.model, resource_id,
                           self.primary_key)
-        if resource is None:
-            detail = 'No resource with ID {0}'.format(resource_id)
+        # We check here whether there actually is an instance of the
+        # correct type and ID.
+        #
+        # The first condition is True exactly when there is no row in
+        # the table with the given primary key value. The second is True
+        # in the special case when the resource exists but is a subclass
+        # of the actual model for this API; this may happen if the model
+        # is a polymorphic subclass of another class using a single
+        # inheritance table.
+        if resource is None or get_model(resource) is not self.model:
+            detail = 'no resource of type {0} with ID {1}'
+            detail = detail.format(collection_name(self.model), resource_id)
             return error_response(404, detail=detail)
         return self._get_resource_helper(resource)
 
@@ -378,8 +410,19 @@ class API(APIBase):
         was_deleted = False
         instance = get_by(self.session, self.model, resource_id,
                           self.primary_key)
-        if instance is None:
-            detail = 'No resource found with ID {0}'.format(resource_id)
+        found_model = get_model(instance)
+        # If no instance of the model exists with the specified instance ID,
+        # return a 404 response.
+        #
+        # The first condition is True exactly when there is no row in
+        # the table with the given primary key value. The second is True
+        # in the special case when the resource exists but is a subclass
+        # of the actual model for this API; this may happen if the model
+        # is a polymorphic subclass of another class using a single
+        # inheritance table.
+        if instance is None or found_model is not self.model:
+            detail = 'No resource found with type {0} and ID {1}'
+            detail = detail.format(collection_name(self.model), resource_id)
             return error_response(404, detail=detail)
         self.session.delete(instance)
         was_deleted = len(self.session.deleted) > 0
@@ -612,26 +655,36 @@ class API(APIBase):
         # Get the instance on which to set the new attributes.
         instance = get_by(self.session, self.model, resource_id,
                           self.primary_key)
+        found_model = get_model(instance)
         # If no instance of the model exists with the specified instance ID,
         # return a 404 response.
-        if instance is None:
-            detail = 'No instance with ID {0} in model {1}'.format(resource_id,
-                                                                   self.model)
+        #
+        # The first condition is True exactly when there is no row in
+        # the table with the given primary key value. The second is True
+        # in the special case when the resource exists but is a subclass
+        # of the actual model for this API; this may happen if the model
+        # is a polymorphic subclass of another class using a single
+        # inheritance table.
+        if instance is None or found_model is not self.model:
+            detail = 'No resource found with type {0} and ID {1}'
+            detail = detail.format(collection_name(self.model), resource_id)
             return error_response(404, detail=detail)
         # Unwrap the data from the collection name key.
         data = data.pop('data', {})
         if 'type' not in data:
-            message = 'Must specify correct data type'
-            return error_response(400, detail=message)
+            detail = 'Missing "type" element'
+            return error_response(400, detail=detail)
         if 'id' not in data:
-            message = 'Must specify resource ID'
-            return error_response(400, detail=message)
+            detail = 'Missing resource ID'
+            return error_response(400, detail=detail)
         type_ = data.pop('type')
         id_ = data.pop('id')
+        # Check that the requested type matches the expected collection
+        # name for this model.
         if type_ != self.collection_name:
-            message = ('Type must be {0}, not'
-                       ' {1}').format(self.collection_name, type_)
-            return error_response(409, detail=message)
+            detail = 'expected type {0}, not {1}'
+            detail = detail.format(self.collection_name, type_)
+            return error_response(409, detail=detail)
         if id_ != resource_id:
             message = 'ID must be {0}, not {1}'.format(resource_id, id_)
             return error_response(409, detail=message)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,11 +42,16 @@ from sqlalchemy.types import CHAR
 from sqlalchemy.types import TypeDecorator
 
 from flask.ext.restless import APIManager
+from flask.ext.restless import collection_name
 from flask.ext.restless import CONTENT_TYPE
 from flask.ext.restless import DefaultSerializer
 from flask.ext.restless import DefaultDeserializer
 from flask.ext.restless import DeserializationException
+from flask.ext.restless import model_for
+from flask.ext.restless import primary_key_for
 from flask.ext.restless import SerializationException
+from flask.ext.restless import serializer_for
+from flask.ext.restless import url_for
 
 dumps = json.dumps
 loads = json.loads
@@ -66,6 +71,10 @@ IS_PYTHON2 = (sys.version_info[0] == 2)
 
 #: Tuple of objects representing types.
 CLASS_TYPES = (types.TypeType, types.ClassType) if IS_PYTHON2 else (type, )
+
+#: Global helper functions used by Flask-Restless
+GLOBAL_FUNCS = [model_for, url_for, collection_name, serializer_for,
+                primary_key_for]
 
 
 class raise_s_exception(DefaultSerializer):
@@ -397,3 +406,15 @@ class ManagerTestBase(SQLAlchemyTestBase):
         """
         super(ManagerTestBase, self).setUp()
         self.manager = APIManager(self.flaskapp, session=self.session)
+
+    # HACK If we don't include this, there seems to be an issue with the
+    # globally known APIManager objects not being cleared after every test.
+    def tearDown(self):
+        """Clear the :class:`~flask.ext.restless.APIManager` objects
+        known by the global helper functions :data:`model_for`,
+        :data:`url_for`, etc.
+
+        """
+        super(ManagerTestBase, self).tearDown()
+        for func in GLOBAL_FUNCS:
+            func.created_managers.clear()

--- a/tests/test_jsonapi/test_updating_resources.py
+++ b/tests/test_jsonapi/test_updating_resources.py
@@ -28,6 +28,7 @@ from sqlalchemy import Integer
 from sqlalchemy import Unicode
 from sqlalchemy.orm import relationship
 
+from ..helpers import check_sole_error
 from ..helpers import dumps
 from ..helpers import loads
 from ..helpers import ManagerTestBase
@@ -357,10 +358,15 @@ class TestUpdatingResources(ManagerTestBase):
         person = self.Person(id=1)
         self.session.add(person)
         self.session.commit()
-        data = dict(data=dict(type='bogus', id='1'))
+        data = {
+            'data': {
+                'type': 'bogus',
+                'id': '1'
+            }
+        }
         response = self.app.patch('/api/person/1', data=dumps(data))
-        assert response.status_code == 409
-        # TODO test for error details
+        check_sole_error(response, 409, ['expected', 'type', 'person',
+                                         'bogus'])
 
     def test_conflicting_id(self):
         """Tests that an attempt to update a resource with the wrong ID causes

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -292,20 +292,6 @@ class TestAPIManager(ManagerTestBase):
         self.Tag = Tag
         self.Base.metadata.create_all()
 
-    # HACK If we don't include this, there seems to be an issue with the
-    # globally known APIManager objects not being cleared after every test.
-    def tearDown(self):
-        """Clear the :class:`flask.ext.restless.APIManager` objects known by
-        the global functions :data:`model_for`, :data:`url_for`, and
-        :data:`collection_name`.
-
-        """
-        super(TestAPIManager, self).tearDown()
-        model_for.created_managers.clear()
-        url_for.created_managers.clear()
-        collection_name.created_managers.clear()
-        serializer_for.created_managers.clear()
-
     def test_url_for(self):
         """Tests the global :func:`flask.ext.restless.url_for` function."""
         self.manager.create_api(self.Person, collection_name='people')

--- a/tests/test_polymorphism.py
+++ b/tests/test_polymorphism.py
@@ -1,0 +1,435 @@
+# test_polymorphism.py - unit tests for polymorphic models
+#
+# Copyright 2011 Lincoln de Sousa <lincoln@comum.org>.
+# Copyright 2012, 2013, 2014, 2015, 2016 Jeffrey Finkelstein
+#           <jeffrey.finkelstein@gmail.com> and contributors.
+#
+# This file is part of Flask-Restless.
+#
+# Flask-Restless is distributed under both the GNU Affero General Public
+# License version 3 and under the 3-clause BSD license. For more
+# information, see LICENSE.AGPL and LICENSE.BSD.
+"""Unit tests for interacting with polymorphic models.
+
+The tests in this module use models defined using `single table
+inheritance`_.
+
+.. _single table inheritance: http://docs.sqlalchemy.org/en/latest/orm/inheritance.html#single-table-inheritance
+
+"""
+from operator import itemgetter
+
+from sqlalchemy import Column
+from sqlalchemy import Integer
+from sqlalchemy import Enum
+from sqlalchemy import Unicode
+
+from flask.ext.restless import DefaultSerializer
+
+from .helpers import check_sole_error
+from .helpers import dumps
+from .helpers import loads
+from .helpers import ManagerTestBase
+
+
+class PolymorphismTestBase(ManagerTestBase):
+    """Base class for tests of APIs created for polymorphic models
+    defined using single table inheritance.
+
+    """
+
+    def setUp(self):
+        """Creates polymorphic models using single table inheritance."""
+        super(PolymorphismTestBase, self).setUp()
+
+        class Employee(self.Base):
+            __tablename__ = 'employee'
+            id = Column(Integer, primary_key=True)
+            type = Column(Enum('employee', 'manager'), nullable=False)
+            name = Column(Unicode)
+            __mapper_args__ = {
+                'polymorphic_on': type,
+                'polymorphic_identity': 'employee'
+            }
+
+        # This model inherits directly from the `Employee` class, so
+        # there is only one table being used.
+        class Manager(Employee):
+            __mapper_args__ = {
+                'polymorphic_identity': 'manager'
+            }
+
+        self.Employee = Employee
+        self.Manager = Manager
+        self.Base.metadata.create_all()
+
+
+class FetchingTestBase(PolymorphismTestBase):
+    """Base class for test cases for fetching resources."""
+
+    def setUp(self):
+        super(FetchingTestBase, self).setUp()
+
+        # Create the APIs for the Employee and Manager.
+        self.apimanager = self.manager
+        self.apimanager.create_api(self.Employee)
+        self.apimanager.create_api(self.Manager)
+
+        # Populate the database. Store a reference to the actual
+        # instances so that test methods in subclasses can access them.
+        self.employee = self.Employee(id=1)
+        self.manager = self.Manager(id=2)
+        self.session.add_all([self.employee, self.manager])
+        self.session.commit()
+
+
+class TestFetchCollection(FetchingTestBase):
+    """Tests for fetching a collection of resources defined using single
+    table inheritance.
+
+    """
+
+    def test_subclass(self):
+        """Tests that fetching a collection at the subclass endpoint
+        yields only instance of the subclass.
+
+        """
+        response = self.app.get('/api/manager')
+        assert response.status_code == 200
+        document = loads(response.data)
+        managers = document['data']
+        assert len(managers) == 1
+        manager = managers[0]
+        assert 'manager' == manager['type']
+        assert '2' == manager['id']
+
+    def test_superclass(self):
+        """Tests that fetching a collection at the superclass endpoint
+        yields instances of both the subclass and the superclass.
+
+        """
+        response = self.app.get('/api/employee')
+        assert response.status_code == 200
+        document = loads(response.data)
+        employees = document['data']
+        employees = sorted(employees, key=itemgetter('id'))
+        employee_types = list(map(itemgetter('type'), employees))
+        employee_ids = list(map(itemgetter('id'), employees))
+        assert ['employee', 'manager'] == employee_types
+        assert ['1', '2'] == employee_ids
+
+    def test_heterogeneous_serialization(self):
+        """Tests that each object is serialized using the serializer
+        specified in :meth:`APIManager.create_api`.
+
+        """
+
+        class EmployeeSerializer(DefaultSerializer):
+
+            def serialize(self, instance, *args, **kw):
+                superserialize = super(EmployeeSerializer, self).serialize
+                result = superserialize(instance, *args, **kw)
+                result['data']['attributes']['foo'] = 'bar'
+                return result
+
+        class ManagerSerializer(DefaultSerializer):
+
+            def serialize(self, instance, *args, **kw):
+                superserialize = super(ManagerSerializer, self).serialize
+                result = superserialize(instance, *args, **kw)
+                result['data']['attributes']['baz'] = 'xyzzy'
+                return result
+
+        self.apimanager.create_api(self.Employee, url_prefix='/api2',
+                                   serializer_class=EmployeeSerializer)
+        self.apimanager.create_api(self.Manager, url_prefix='/api2',
+                                   serializer_class=ManagerSerializer)
+
+        response = self.app.get('/api/employee')
+        assert response.status_code == 200
+        document = loads(response.data)
+        employees = document['data']
+        assert len(employees) == 2
+        employees = sorted(employees, key=itemgetter('id'))
+        assert employees[0]['attributes']['foo'] == 'bar'
+        assert employees[1]['attributes']['baz'] == 'xyzzy'
+
+
+class TestFetchResource(FetchingTestBase):
+    """Tests for fetching a single resource defined using single table
+    inheritance.
+
+    """
+
+    def test_subclass_at_subclass(self):
+        """Tests for fetching a resource of the subclass type at the URL
+        for the subclass.
+
+        """
+        response = self.app.get('/api/employee/1')
+        assert response.status_code == 200
+        document = loads(response.data)
+        resource = document['data']
+        assert resource['type'] == 'employee'
+        assert resource['id'] == str(self.employee.id)
+
+    def superclass_at_superclass(self):
+        """Tests for fetching a resource of the superclass type at the
+        URL for the superclass.
+
+        """
+        response = self.app.get('/api/manager/2')
+        assert response.status_code == 200
+        document = loads(response.data)
+        resource = document['data']
+        assert resource['type'] == 'manager'
+        assert resource['id'] == str(self.manager.id)
+
+    def test_superclass_at_subclass(self):
+        """Tests that attempting to fetch a resource of the superclass
+        type at the subclass endpoint causes an exception.
+
+        """
+        response = self.app.get('/api/manager/1')
+        assert response.status_code == 404
+
+    def test_subclass_at_superclass(self):
+        """Tests that attempting to fetch a resource of the subclass
+        type at the superclass endpoint causes an exception.
+
+        """
+        response = self.app.get('/api/employee/2')
+        assert response.status_code == 404
+
+
+class TestCreating(PolymorphismTestBase):
+    """Tests for APIs created for polymorphic models defined using
+    single table inheritance.
+
+    """
+
+    def setUp(self):
+        super(TestCreating, self).setUp()
+        self.manager.create_api(self.Employee, methods=['POST'])
+        self.manager.create_api(self.Manager, methods=['POST'])
+
+    def test_subclass_at_subclass(self):
+        """Tests for creating a resource of the subclass type at the URL
+        for the subclass.
+
+        """
+        data = {
+            'data': {
+                'type': 'manager'
+            }
+        }
+        response = self.app.post('/api/manager', data=dumps(data))
+        assert response.status_code == 201
+        document = loads(response.data)
+        manager = document['data']
+        manager_in_db = self.session.query(self.Manager).first()
+        assert manager['id'] == str(manager_in_db.id)
+        assert manager['type'] == 'manager'
+
+    def test_superclass_at_superclass(self):
+        """Tests for creating a resource of the superclass type at the
+        URL for the superclass.
+
+        """
+        data = {
+            'data': {
+                'type': 'employee'
+            }
+        }
+        response = self.app.post('/api/employee', data=dumps(data))
+        assert response.status_code == 201
+        document = loads(response.data)
+        employee = document['data']
+        employee_in_db = self.session.query(self.Employee).first()
+        assert employee['id'] == str(employee_in_db.id)
+        assert employee['type'] == 'employee'
+
+    def test_subclass_at_superclass(self):
+        """Tests that attempting to create a resource of the subclass
+        type at the URL for the superclass causes an error.
+
+        """
+        data = {
+            'data': {
+                'type': 'manager'
+            }
+        }
+        response = self.app.post('/api/employee', data=dumps(data))
+        check_sole_error(response, 409, ['Failed', 'deserialize', 'expected',
+                                         'type', 'employee', 'manager'])
+
+    def test_superclass_at_subclass(self):
+        """Tests that attempting to create a resource of the superclass
+        type at the URL for the subclass causes an error.
+
+        """
+        data = {
+            'data': {
+                'type': 'employee'
+            }
+        }
+        response = self.app.post('/api/manager', data=dumps(data))
+        check_sole_error(response, 409, ['Failed', 'deserialize', 'expected',
+                                         'type', 'manager', 'employee'])
+
+
+class TestDeleting(PolymorphismTestBase):
+    """Tests for deleting resources."""
+
+    def setUp(self):
+        super(TestDeleting, self).setUp()
+
+        # Create the APIs for the Employee and Manager.
+        self.manager.create_api(self.Employee, methods=['DELETE'])
+        self.manager.create_api(self.Manager, methods=['DELETE'])
+
+        # Populate the database. Store a reference to the actual
+        # instances so that test methods in subclasses can access them.
+        self.employee = self.Employee(id=1)
+        self.manager = self.Manager(id=2)
+        self.all_employees = [self.employee, self.manager]
+        self.session.add_all(self.all_employees)
+        self.session.commit()
+
+    def test_subclass_at_subclass(self):
+        """Tests for deleting a resource of the subclass type at the URL
+        for the subclass.
+
+        """
+        response = self.app.delete('/api/manager/2')
+        assert response.status_code == 204
+        assert self.session.query(self.Manager).count() == 0
+        assert self.session.query(self.Employee).all() == [self.employee]
+
+    def test_superclass_at_superclass(self):
+        """Tests for deleting a resource of the superclass type at the
+        URL for the superclass.
+
+        """
+        response = self.app.delete('/api/employee/1')
+        assert response.status_code == 204
+        assert self.session.query(self.Manager).all() == [self.manager]
+        assert self.session.query(self.Employee).all() == [self.manager]
+
+    def test_subclass_at_superclass(self):
+        """Tests that attempting to delete a resource of the subclass
+        type at the URL for the superclass causes an error.
+
+        """
+        response = self.app.delete('/api/employee/2')
+        check_sole_error(response, 404, ['No resource found', 'type',
+                                         'employee', 'ID', '2'])
+        assert self.session.query(self.Manager).all() == [self.manager]
+        assert self.session.query(self.Employee).all() == self.all_employees
+
+    def test_superclass_at_subclass(self):
+        """Tests that attempting to delete a resource of the superclass
+        type at the URL for the subclass causes an error.
+
+        """
+        response = self.app.delete('/api/manager/1')
+        check_sole_error(response, 404, ['No resource found', 'type',
+                                         'manager', 'ID', '1'])
+        assert self.session.query(self.Manager).all() == [self.manager]
+        assert self.session.query(self.Employee).all() == self.all_employees
+
+
+class TestUpdating(PolymorphismTestBase):
+    """Tests for updating resources."""
+
+    def setUp(self):
+        super(TestUpdating, self).setUp()
+
+        # Create the APIs for the Employee and Manager.
+        self.manager.create_api(self.Employee, methods=['PATCH'])
+        self.manager.create_api(self.Manager, methods=['PATCH'])
+
+        # Populate the database. Store a reference to the actual
+        # instances so that test methods in subclasses can access them.
+        self.employee = self.Employee(id=1, name=u'foo')
+        self.manager = self.Manager(id=2, name=u'foo')
+        self.session.add_all([self.employee, self.manager])
+        self.session.commit()
+
+    def test_subclass_at_subclass(self):
+        """Tests for updating a resource of the subclass type at the URL
+        for the subclass.
+
+        """
+        data = {
+            'data': {
+                'type': 'manager',
+                'id': '2',
+                'attributes': {
+                    'name': u'bar'
+                }
+            }
+        }
+        response = self.app.patch('/api/manager/2', data=dumps(data))
+        assert response.status_code == 204
+        assert self.manager.name == u'bar'
+
+    def test_superclass_at_superclass(self):
+        """Tests for updating a resource of the superclass type at the
+        URL for the superclass.
+
+        """
+        data = {
+            'data': {
+                'type': 'employee',
+                'id': '1',
+                'attributes': {
+                    'name': u'bar'
+                }
+            }
+        }
+        response = self.app.patch('/api/employee/1', data=dumps(data))
+        assert response.status_code == 204
+        assert self.employee.name == u'bar'
+
+    def test_subclass_at_superclass(self):
+        """Tests that attempting to update a resource of the subclass
+        type at the URL for the superclass causes an error.
+
+        """
+        # In this test, the JSON document has the correct type and ID,
+        # but the URL has the wrong type. Even though "manager" is a
+        # subtype of "employee" Flask-Restless doesn't allow a mismatch
+        # of types when updating.
+        data = {
+            'data': {
+                'type': 'manager',
+                'id': '2',
+                'attributes': {
+                    'name': u'bar'
+                }
+            }
+        }
+        response = self.app.patch('/api/employee/2', data=dumps(data))
+        check_sole_error(response, 404, ['No resource found', 'type',
+                                         'employee', 'ID', '2'])
+
+    def test_superclass_at_subclass(self):
+        """Tests that attempting to update a resource of the superclass
+        type at the URL for the subclass causes an error.
+
+        """
+        # In this test, the JSON document has the correct type and ID,
+        # but the URL has the wrong type.
+        data = {
+            'data': {
+                'type': 'employee',
+                'id': '1',
+                'attributes': {
+                    'name': u'bar'
+                }
+            }
+        }
+        response = self.app.patch('/api/manager/1', data=dumps(data))
+        check_sole_error(response, 404, ['No resource found', 'type',
+                                         'manager', 'ID', '1'])


### PR DESCRIPTION
This commit adds support for fetching, creating, updating, and deleting
at endpoints corresponding to APIs created for polymorphic models
defined using single table inheritance.

This also changes the default serializer so that it supports
heterogeneous collections directly.

Fixes issue #200.

This is currently a work-in-progress: it needs documentation to explain what operations are supported. This could be an opportunity to create a special section of the documentation on "Association proxies, polymorphic tables, hybrid properties, etc."