### PR TITLE
Replaces "flask.ext." with "flask_".

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,7 @@
 API
 ===
 
-.. module:: flask.ext.restless
+.. module:: flask_restless
 
 This part of the documentation documents all the public classes and functions
 in Flask-Restless.

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -15,7 +15,7 @@ have a primary key column named ``id`` of type
 .. sourcecode:: python
 
    from flask import Flask
-   from flask.ext.sqlalchemy import SQLAlchemy
+   from flask_sqlalchemy import SQLAlchemy
 
    app = Flask(__name__)
    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
@@ -66,7 +66,7 @@ If you are using pure SQLAlchemy::
 Second, instantiate an :class:`APIManager` object with the
 :class:`~flask.Flask` and :class:`~flask_sqlalchemy.SQLAlchemy` objects::
 
-    from flask.ext.restless import APIManager
+    from flask_restless import APIManager
 
     manager = APIManager(app, flask_sqlalchemy_db=db)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,3 +1,1 @@
-.. currentmodule:: flask.ext.restless
-
 .. include:: ../CHANGES

--- a/docs/creating.rst
+++ b/docs/creating.rst
@@ -7,8 +7,8 @@ For the purposes of concreteness in this section, suppose we have executed the
 following code on the server::
 
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
-    from flask.ext.restless import APIManager
+    from flask_sqlalchemy import SQLAlchemy
+    from flask_restless import APIManager
 
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'

--- a/docs/deleting.rst
+++ b/docs/deleting.rst
@@ -1,5 +1,3 @@
-.. _deleting:
-
 Deleting resources
 ==================
 
@@ -7,8 +5,8 @@ For the purposes of concreteness in this section, suppose we have executed the
 following code on the server::
 
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
-    from flask.ext.restless import APIManager
+    from flask_sqlalchemy import SQLAlchemy
+    from flask_restless import APIManager
 
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'

--- a/docs/fetching.rst
+++ b/docs/fetching.rst
@@ -21,8 +21,8 @@ For the purposes of concreteness in this section, suppose we have executed the
 following code on the server::
 
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
-    from flask.ext.restless import APIManager
+    from flask_sqlalchemy import SQLAlchemy
+    from flask_restless import APIManager
 
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -201,9 +201,9 @@ This may be used, for example, if all :http:method:`post` requests require
 authentication::
 
     from flask import Flask
-    from flask.ext.restless import APIManager
-    from flask.ext.restless import ProcessingException
-    from flask.ext.login import current_user
+    from flask_restless import APIManager
+    from flask_restless import ProcessingException
+    from flask_login import current_user
     from mymodels import User
     from mymodels import session
 
@@ -262,9 +262,9 @@ Requiring authentication for some methods
 If you want certain HTTP methods to require authentication, use preprocessors::
 
     from flask import Flask
-    from flask.ext.restless import APIManager
-    from flask.ext.restless import ProcessingException
-    from flask.ext.login import current_user
+    from flask_restless import APIManager
+    from flask_restless import ProcessingException
+    from flask_login import current_user
     from mymodels import User
 
     def auth_func(*args, **kwargs):

--- a/docs/requestformat.rst
+++ b/docs/requestformat.rst
@@ -164,7 +164,7 @@ sent from the server to the client) using the
 :meth:`flask.Blueprint.after_request` method::
 
     from flask import Flask
-    from flask.ext.restless import APIManager
+    from flask_restless import APIManager
 
     def add_cors_headers(response):
         response.headers['Access-Control-Allow-Origin'] = 'example.com'

--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -18,19 +18,19 @@ resource objects that satisfy the JSON API specification, your client will
 receive non-compliant responses!
 
 Your serializer classes must be a subclass of
-:class:`~flask.ext.restless.Serializer` and can override the
-:meth:`~flask.ext.restless.Serializer.serialize` and
-:meth:`~flask.ext.restless.Serializer.serialize_many` methods to provide custom
+:class:`~flask_restless.Serializer` and can override the
+:meth:`~flask_restless.Serializer.serialize` and
+:meth:`~flask_restless.Serializer.serialize_many` methods to provide custom
 serialization (however, we recommend overriding the
-:class:`~flask.ext.restless.DefaultSerializer` class, as it provides some
+:class:`~flask_restless.DefaultSerializer` class, as it provides some
 useful behavior in its constructor). These methods take an instance or
 instances as input and return a dictionary representing a JSON API
 document. Each also accepts an ``only`` keyword argument, indicating the sparse
 fieldsets requested by the client. When implementing your custom serializer,
-you may wish to override the :class:`flask.ext.restless.DefaultSerializer`
+you may wish to override the :class:`flask_restless.DefaultSerializer`
 class::
 
-    from flask.ext.restless import DefaultSerializer
+    from flask_restless import DefaultSerializer
 
     class MySerializer(DefaultSerializer):
 
@@ -57,13 +57,13 @@ and ``'type'`` must always appear, regardless of whether they appear in
 object.
 
 Flask-Restless also provides functional access to the default serialization,
-via the :func:`~flask.ext.restless.simple_serialize` and
-:func:`~flask.ext.restless.simple_serialize_many` functions, which return the
+via the :func:`~flask_restless.simple_serialize` and
+:func:`~flask_restless.simple_serialize_many` functions, which return the
 result of the built-in default serialization.
 
 For deserialization, define your custom deserialization class like this::
 
-    from flask.ext.restless import DefaultDeserializer
+    from flask_restless import DefaultDeserializer
 
     class MyDeserializer(DefaultDeserializer):
 
@@ -76,14 +76,14 @@ objects. The function must return an instance of the model that has the
 requested fields. If you override the constructor, it must take two positional
 arguments, `session` and `model`.
 
-Your code can raise a :exc:`~flask.ext.restless.SerializationException` when
+Your code can raise a :exc:`~flask_restless.SerializationException` when
 overriding the :meth:`DefaultSerializer.serialize` method, and similarly a
-:exc:`~flask.ext.restless.DeserializationException` in the
+:exc:`~flask_restless.DeserializationException` in the
 :meth:`DefaultDeserializer.deserialize` method; Flask-Restless will
 automatically catch those exceptions and format a `JSON API error response`_.
 If you wish to collect multiple exceptions (for example, if several fields of a
 resource provided to the :meth:`deserialize` method fail validation) you can
-raise a :exc:`~flask.ext.restless.MultipleExceptions` exception, providing a
+raise a :exc:`~flask_restless.MultipleExceptions` exception, providing a
 list of other serialization or deserialization exceptions at instantiation
 time.
 

--- a/docs/updating.rst
+++ b/docs/updating.rst
@@ -1,5 +1,3 @@
-.. _updating:
-
 Updating resources
 ==================
 
@@ -7,8 +5,8 @@ For the purposes of concreteness in this section, suppose we have executed the
 following code on the server::
 
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
-    from flask.ext.restless import APIManager
+    from flask_sqlalchemy import SQLAlchemy
+    from flask_restless import APIManager
 
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'

--- a/docs/updatingrelationships.rst
+++ b/docs/updatingrelationships.rst
@@ -7,8 +7,8 @@ For the purposes of concreteness in this section, suppose we have executed the
 following code on the server::
 
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
-    from flask.ext.restless import APIManager
+    from flask_sqlalchemy import SQLAlchemy
+    from flask_restless import APIManager
 
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'

--- a/examples/clients/jquery/__main__.py
+++ b/examples/clients/jquery/__main__.py
@@ -39,8 +39,8 @@ import os
 import os.path
 
 from flask import Flask, render_template
-from flask.ext.restless import APIManager
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_restless import APIManager
+from flask_sqlalchemy import SQLAlchemy
 
 
 # Step 0: the database in this example is at './test.sqlite'.

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,17 +1,17 @@
 import flask
-import flask.ext.sqlalchemy
-import flask.ext.restless
+import flask_sqlalchemy
+import flask_restless
 
 # Create the Flask application and the Flask-SQLAlchemy object.
 app = flask.Flask(__name__)
 app.config['DEBUG'] = True
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
-db = flask.ext.sqlalchemy.SQLAlchemy(app)
+db = flask_sqlalchemy.SQLAlchemy(app)
 
 # Create your Flask-SQLALchemy models as usual but with the following
 # restriction: they must have an __init__ method that accepts keyword
 # arguments for all columns (the constructor in
-# flask.ext.sqlalchemy.SQLAlchemy.Model supplies such a method, so you
+# flask_sqlalchemy.SQLAlchemy.Model supplies such a method, so you
 # don't need to declare a new one).
 class Person(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -31,7 +31,7 @@ class Article(db.Model):
 db.create_all()
 
 # Create the Flask-Restless API manager.
-manager = flask.ext.restless.APIManager(app, flask_sqlalchemy_db=db)
+manager = flask_restless.APIManager(app, flask_sqlalchemy_db=db)
 
 # Create API endpoints, which will be available at /api/<tablename> by
 # default. Allowed HTTP methods can be specified as well.

--- a/examples/server_configurations/authentication/__main__.py
+++ b/examples/server_configurations/authentication/__main__.py
@@ -41,10 +41,10 @@ import os
 import os.path
 
 from flask import Flask, render_template, redirect, url_for
-from flask.ext.login import current_user, login_user, LoginManager, UserMixin
-from flask.ext.restless import APIManager, ProcessingException, NO_CHANGE
-from flask.ext.sqlalchemy import SQLAlchemy
-from flask.ext.wtf import PasswordField, SubmitField, TextField, Form
+from flask_login import current_user, login_user, LoginManager, UserMixin
+from flask_restless import APIManager, ProcessingException, NO_CHANGE
+from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import PasswordField, SubmitField, TextField, Form
 
 # Step 0: the database in this example is at './test.sqlite'.
 DATABASE = os.path.join(os.path.dirname(os.path.abspath(__file__)),

--- a/examples/server_configurations/custom_serialization.py
+++ b/examples/server_configurations/custom_serialization.py
@@ -50,10 +50,10 @@ make requests using any web client.
 
 """
 from flask import Flask
-from flask.ext.restless import APIManager
-from flask.ext.restless import DefaultSerializer
-from flask.ext.restless import DefaultDeserializer
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_restless import APIManager
+from flask_restless import DefaultSerializer
+from flask_restless import DefaultDeserializer
+from flask_sqlalchemy import SQLAlchemy
 from marshmallow import post_load
 from marshmallow_jsonapi import fields
 from marshmallow_jsonapi import Schema

--- a/examples/server_configurations/separate_endpoints.py
+++ b/examples/server_configurations/separate_endpoints.py
@@ -14,21 +14,21 @@
 
 """
 import flask
-import flask.ext.sqlalchemy
-import flask.ext.restless
+import flask_sqlalchemy
+import flask_restless
 
 # Create the Flask application and the Flask-SQLAlchemy object.
 app = flask.Flask(__name__)
 app.config['DEBUG'] = True
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
-db = flask.ext.sqlalchemy.SQLAlchemy(app)
+db = flask_sqlalchemy.SQLAlchemy(app)
 
 # Create your Flask-SQLALchemy models as usual but with the following two
 # (reasonable) restrictions:
 #   1. They must have a primary key column of type sqlalchemy.Integer or
 #      type sqlalchemy.Unicode.
 #   2. They must have an __init__ method which accepts keyword arguments for
-#      all columns (the constructor in flask.ext.sqlalchemy.SQLAlchemy.Model
+#      all columns (the constructor in flask_sqlalchemy.SQLAlchemy.Model
 #      supplies such a method, so you don't need to declare a new one).
 class Person(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -50,7 +50,7 @@ class Computer(db.Model):
 db.create_all()
 
 # Create the Flask-Restless API manager.
-manager = flask.ext.restless.APIManager(app, flask_sqlalchemy_db=db)
+manager = flask_restless.APIManager(app, flask_sqlalchemy_db=db)
 
 # Create API endpoints, each at a different URL and with different allowed HTTP
 # methods, but which all affect the Person model.

--- a/flask_restless/__init__.py
+++ b/flask_restless/__init__.py
@@ -21,7 +21,7 @@ __version__ = '1.0.0b2-dev'
 
 # The following names are available as part of the public API for
 # Flask-Restless. End users of this package can import these names by doing
-# ``from flask.ext.restless import APIManager``, for example.
+# ``from flask_restless import APIManager``, for example.
 from .helpers import collection_name
 from .helpers import model_for
 from .helpers import serializer_for

--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -100,7 +100,7 @@ class APIManager(object):
     `session` is the :class:`~sqlalchemy.orm.session.Session` object in
     which changes to the database will be made.
 
-    `flask_sqlalchemy_db` is the :class:`~flask.ext.sqlalchemy.SQLAlchemy`
+    `flask_sqlalchemy_db` is the :class:`~flask_sqlalchemy.SQLAlchemy`
     object with which `app` has been registered and which contains the
     database models for which API endpoints will be created.
 
@@ -109,7 +109,7 @@ class APIManager(object):
     For example, to use this class with models defined in pure SQLAlchemy::
 
         from flask import Flask
-        from flask.ext.restless import APIManager
+        from flask_restless import APIManager
         from sqlalchemy import create_engine
         from sqlalchemy.orm.session import sessionmaker
 
@@ -122,8 +122,8 @@ class APIManager(object):
     and with models defined with Flask-SQLAlchemy::
 
         from flask import Flask
-        from flask.ext.restless import APIManager
-        from flask.ext.sqlalchemy import SQLAlchemy
+        from flask_restless import APIManager
+        from flask_sqlalchemy import SQLAlchemy
 
         app = Flask(__name__)
         db = SQLALchemy(app)
@@ -338,7 +338,7 @@ class APIManager(object):
         To use this method with pure SQLAlchemy, for example::
 
             from flask import Flask
-            from flask.ext.restless import APIManager
+            from flask_restless import APIManager
             from sqlalchemy import create_engine
             from sqlalchemy.orm.session import sessionmaker
 
@@ -362,8 +362,8 @@ class APIManager(object):
         and with models defined with Flask-SQLAlchemy::
 
             from flask import Flask
-            from flask.ext.restless import APIManager
-            from flask.ext.sqlalchemy import SQLAlchemy
+            from flask_restless import APIManager
+            from flask_sqlalchemy import SQLAlchemy
 
             db = SQLALchemy(app)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,7 +26,7 @@ from flask import Flask
 from flask import json
 try:
     from flask.ext import sqlalchemy as flask_sqlalchemy
-    from flask.ext.sqlalchemy import SQLAlchemy
+    from flask_sqlalchemy import SQLAlchemy
 except ImportError:
     has_flask_sqlalchemy = False
 else:
@@ -41,17 +41,17 @@ from sqlalchemy.orm.session import Session as SessionBase
 from sqlalchemy.types import CHAR
 from sqlalchemy.types import TypeDecorator
 
-from flask.ext.restless import APIManager
-from flask.ext.restless import collection_name
-from flask.ext.restless import CONTENT_TYPE
-from flask.ext.restless import DefaultSerializer
-from flask.ext.restless import DefaultDeserializer
-from flask.ext.restless import DeserializationException
-from flask.ext.restless import model_for
-from flask.ext.restless import primary_key_for
-from flask.ext.restless import SerializationException
-from flask.ext.restless import serializer_for
-from flask.ext.restless import url_for
+from flask_restless import APIManager
+from flask_restless import collection_name
+from flask_restless import CONTENT_TYPE
+from flask_restless import DefaultSerializer
+from flask_restless import DefaultDeserializer
+from flask_restless import DeserializationException
+from flask_restless import model_for
+from flask_restless import primary_key_for
+from flask_restless import SerializationException
+from flask_restless import serializer_for
+from flask_restless import url_for
 
 dumps = json.dumps
 loads = json.loads
@@ -385,22 +385,22 @@ class SQLAlchemyTestBase(FlaskTestBase, DatabaseMixin):
 
 class ManagerTestBase(SQLAlchemyTestBase):
     """Base class for tests that use a SQLAlchemy database and an
-    :class:`~flask.ext.restless.APIManager`.
+    :class:`~flask_restless.APIManager`.
 
     Nearly all test classes should subclass this class. Since we strive
     to make Flask-Restless compliant with plain old SQLAlchemy first,
     the default database abstraction layer used by tests in this class
     will be SQLAlchemy. Test classes requiring Flask-SQLAlchemy must
-    instantiate their own :class:`~flask.ext.restless.APIManager`.
+    instantiate their own :class:`~flask_restless.APIManager`.
 
-    The :class:`~flask.ext.restless.APIManager` instance for use in
+    The :class:`~flask_restless.APIManager` instance for use in
     tests is accessible at ``self.manager``.
 
     """
 
     def setUp(self):
         """Initializes an instance of
-        :class:`~flask.ext.restless.APIManager` with a SQLAlchemy
+        :class:`~flask_restless.APIManager` with a SQLAlchemy
         session.
 
         """
@@ -410,7 +410,7 @@ class ManagerTestBase(SQLAlchemyTestBase):
     # HACK If we don't include this, there seems to be an issue with the
     # globally known APIManager objects not being cleared after every test.
     def tearDown(self):
-        """Clear the :class:`~flask.ext.restless.APIManager` objects
+        """Clear the :class:`~flask_restless.APIManager` objects
         known by the global helper functions :data:`model_for`,
         :data:`url_for`, etc.
 

--- a/tests/test_creating.py
+++ b/tests/test_creating.py
@@ -37,11 +37,11 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 
-from flask.ext.restless import APIManager
-from flask.ext.restless import CONTENT_TYPE
-from flask.ext.restless import DefaultDeserializer
-from flask.ext.restless import DefaultSerializer
-from flask.ext.restless import ProcessingException
+from flask_restless import APIManager
+from flask_restless import CONTENT_TYPE
+from flask_restless import DefaultDeserializer
+from flask_restless import DefaultSerializer
+from flask_restless import ProcessingException
 
 from .helpers import BetterJSONEncoder as JSONEncoder
 from .helpers import check_sole_error
@@ -946,7 +946,7 @@ class TestAssociationProxy(ManagerTestBase):
 
     def setUp(self):
         """Creates the database, the :class:`~flask.Flask` object, the
-        :class:`~flask.ext.restless.manager.APIManager` for that application,
+        :class:`~flask_restless.manager.APIManager` for that application,
         and creates the ReSTful API endpoints for the models used in the test
         methods.
 

--- a/tests/test_deleting.py
+++ b/tests/test_deleting.py
@@ -26,8 +26,8 @@ from sqlalchemy import Integer
 from sqlalchemy import Unicode
 from sqlalchemy.orm import relationship
 
-from flask.ext.restless import APIManager
-from flask.ext.restless import ProcessingException
+from flask_restless import APIManager
+from flask_restless import ProcessingException
 
 from .helpers import dumps
 from .helpers import loads

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -30,9 +30,9 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 
-from flask.ext.restless import APIManager
-from flask.ext.restless import DefaultSerializer
-from flask.ext.restless import ProcessingException
+from flask_restless import APIManager
+from flask_restless import DefaultSerializer
+from flask_restless import ProcessingException
 
 from .helpers import check_sole_error
 from .helpers import dumps
@@ -1552,7 +1552,7 @@ class TestAssociationProxy(ManagerTestBase):
 
     def setUp(self):
         """Creates the database, the :class:`~flask.Flask` object, the
-        :class:`~flask.ext.restless.manager.APIManager` for that application,
+        :class:`~flask_restless.manager.APIManager` for that application,
         and creates the ReSTful API endpoints for the models used in the test
         methods.
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -99,7 +99,7 @@ class TestFiltering(SearchTestBase):
 
     def setUp(self):
         """Creates the database, the :class:`~flask.Flask` object, the
-        :class:`~flask.ext.restless.manager.APIManager` for that application,
+        :class:`~flask_restless.manager.APIManager` for that application,
         and creates the ReSTful API endpoints for the models used in the test
         methods.
 
@@ -971,7 +971,7 @@ class TestOperators(SearchTestBase):
 
     def setUp(self):
         """Creates the database, the :class:`~flask.Flask` object, the
-        :class:`~flask.ext.restless.manager.APIManager` for that application,
+        :class:`~flask_restless.manager.APIManager` for that application,
         and creates the ReSTful API endpoints for the models used in the test
         methods.
 
@@ -1378,7 +1378,7 @@ class TestAssociationProxy(SearchTestBase):
 
     def setUp(self):
         """Creates the database, the :class:`~flask.Flask` object, the
-        :class:`~flask.ext.restless.manager.APIManager` for that application,
+        :class:`~flask_restless.manager.APIManager` for that application,
         and creates the ReSTful API endpoints for the models used in the test
         methods.
 

--- a/tests/test_jsonapi/test_server_responsibilities.py
+++ b/tests/test_jsonapi/test_server_responsibilities.py
@@ -24,7 +24,7 @@ from sqlalchemy import Column
 from sqlalchemy import Unicode
 from sqlalchemy import Integer
 
-from flask.ext.restless import CONTENT_TYPE
+from flask_restless import CONTENT_TYPE
 
 from ..helpers import check_sole_error
 from ..helpers import dumps

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -20,13 +20,13 @@ from sqlalchemy import Unicode
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 
-from flask.ext.restless import APIManager
-from flask.ext.restless import collection_name
-from flask.ext.restless import DefaultSerializer
-from flask.ext.restless import IllegalArgumentError
-from flask.ext.restless import model_for
-from flask.ext.restless import serializer_for
-from flask.ext.restless import url_for
+from flask_restless import APIManager
+from flask_restless import collection_name
+from flask_restless import DefaultSerializer
+from flask_restless import IllegalArgumentError
+from flask_restless import model_for
+from flask_restless import serializer_for
+from flask_restless import url_for
 
 from .helpers import FlaskSQLAlchemyTestBase
 from .helpers import force_content_type_jsonapi
@@ -36,8 +36,8 @@ from .helpers import SQLAlchemyTestBase
 
 
 class TestLocalAPIManager(SQLAlchemyTestBase):
-    """Provides tests for :class:`flask.ext.restless.APIManager` when the tests
-    require that the instance of :class:`flask.ext.restless.APIManager` has not
+    """Provides tests for :class:`flask_restless.APIManager` when the tests
+    require that the instance of :class:`flask_restless.APIManager` has not
     yet been instantiated.
 
     """
@@ -293,7 +293,7 @@ class TestAPIManager(ManagerTestBase):
         self.Base.metadata.create_all()
 
     def test_url_for(self):
-        """Tests the global :func:`flask.ext.restless.url_for` function."""
+        """Tests the global :func:`flask_restless.url_for` function."""
         self.manager.create_api(self.Person, collection_name='people')
         self.manager.create_api(self.Article, collection_name='articles')
         with self.flaskapp.test_request_context():
@@ -335,7 +335,7 @@ class TestAPIManager(ManagerTestBase):
             url_for(self.Person)
 
     def test_collection_name(self):
-        """Tests the global :func:`flask.ext.restless.collection_name`
+        """Tests the global :func:`flask_restless.collection_name`
         function.
 
         """
@@ -351,7 +351,7 @@ class TestAPIManager(ManagerTestBase):
             collection_name(self.Person)
 
     def test_serializer_for(self):
-        """Tests the global :func:`flask.ext.restless.serializer_for`
+        """Tests the global :func:`flask_restless.serializer_for`
         function.
 
         """
@@ -371,7 +371,7 @@ class TestAPIManager(ManagerTestBase):
             serializer_for(self.Person)
 
     def test_model_for(self):
-        """Tests the global :func:`flask.ext.restless.model_for` function."""
+        """Tests the global :func:`flask_restless.model_for` function."""
         self.manager.create_api(self.Person, collection_name='people')
         assert model_for('people') is self.Person
 
@@ -384,8 +384,8 @@ class TestAPIManager(ManagerTestBase):
             model_for('people')
 
     def test_model_for_collection_name(self):
-        """Tests that :func:`flask.ext.restless.model_for` is the inverse of
-        :func:`flask.ext.restless.collection_name`.
+        """Tests that :func:`flask_restless.model_for` is the inverse of
+        :func:`flask_restless.collection_name`.
 
         """
         self.manager.create_api(self.Person, collection_name='people')
@@ -492,7 +492,7 @@ class TestFSA(FlaskSQLAlchemyTestBase):
 
     def test_create_api_before_db_create_all(self):
         """Tests that we can create APIs before
-        :meth:`flask.ext.sqlalchemy.SQLAlchemy.create_all` is called.
+        :meth:`flask_sqlalchemy.SQLAlchemy.create_all` is called.
 
         """
         manager = APIManager(self.flaskapp, flask_sqlalchemy_db=self.db)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -15,7 +15,7 @@ from unittest2 import skip
 from sqlalchemy import Column
 from sqlalchemy import Integer
 
-from flask.ext.restless import CONTENT_TYPE
+from flask_restless import CONTENT_TYPE
 
 from .helpers import loads
 from .helpers import ManagerTestBase

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -37,9 +37,9 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 
-from flask.ext.restless import DefaultSerializer
-from flask.ext.restless import MultipleExceptions
-from flask.ext.restless import SerializationException
+from flask_restless import DefaultSerializer
+from flask_restless import MultipleExceptions
+from flask_restless import SerializationException
 
 from .helpers import check_sole_error
 from .helpers import GUID
@@ -539,7 +539,7 @@ class TestFetchResource(ManagerTestBase):
 
     def test_exception_message(self):
         """Tests that a message specified in the
-        :exc:`~flask.ext.restless.SerializationException` constructor
+        :exc:`~flask_restless.SerializationException` constructor
         appears in an error response.
 
         """

--- a/tests/test_updating.py
+++ b/tests/test_updating.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from unittest2 import skip
 
 try:
-    from flask.ext.sqlalchemy import SQLAlchemy
+    from flask_sqlalchemy import SQLAlchemy
 except ImportError:
     has_flask_sqlalchemy = False
 else:
@@ -42,9 +42,9 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 
-from flask.ext.restless import APIManager
-from flask.ext.restless import CONTENT_TYPE
-from flask.ext.restless import ProcessingException
+from flask_restless import APIManager
+from flask_restless import CONTENT_TYPE
+from flask_restless import ProcessingException
 
 from .helpers import BetterJSONEncoder as JSONEncoder
 from .helpers import check_sole_error
@@ -1102,7 +1102,7 @@ class TestAssociationProxy(ManagerTestBase):
 
     def setUp(self):
         """Creates the database, the :class:`~flask.Flask` object, the
-        :class:`~flask.ext.restless.manager.APIManager` for that application,
+        :class:`~flask_restless.manager.APIManager` for that application,
         and creates the ReSTful API endpoints for the models used in the test
         methods.
 


### PR DESCRIPTION
Flask version 0.11 deprecates imports from `flask.ext.*` in favor import
from "flask_*" for Flask extensions. This commit changes references to,
among others, `flask.ext.restless` to `flask_restless`.