### PR TITLE
Allows attributes with JSON API "reserved" names.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,8 @@ Not yet released.
 - :issue:`508`: flush the session before postprocessors, and commit after.
 - :issue:`536`: adds support for single-table inheritance.
 - :issue:`546`: adds support for joined table inheritance.
+- :issue:`559`: fixes bug that stripped attributes with JSON API reserved names
+  (like "type") when deserializing resources.
 
 Version 1.0.0b1
 ---------------

--- a/flask_restless/helpers.py
+++ b/flask_restless/helpers.py
@@ -381,26 +381,6 @@ def string_to_datetime(model, fieldname, value):
     return value
 
 
-def strings_to_datetimes(model, dictionary):
-    """Returns a new dictionary with all the mappings of `dictionary` but
-    with date strings and intervals mapped to :class:`datetime.datetime` or
-    :class:`datetime.timedelta` objects.
-
-    The keys of `dictionary` are names of fields in the model specified in the
-    constructor of this class. The values are values to set on these fields. If
-    a field name corresponds to a field in the model which is a
-    :class:`sqlalchemy.types.Date`, :class:`sqlalchemy.types.DateTime`, or
-    :class:`sqlalchemy.Interval`, then the returned dictionary will have the
-    corresponding :class:`datetime.datetime` or :class:`datetime.timedelta`
-    Python object as the value of that mapping in place of the string.
-
-    This function outputs a new dictionary; it does not modify the argument.
-
-    """
-    # In Python 2.7+, this should be a dict comprehension.
-    return dict((k, string_to_datetime(model, k, v))
-                for k, v in dictionary.items() if k not in ('type', 'links'))
-
 
 def get_model(instance):
     """Returns the model class of which the specified object is an instance."""

--- a/flask_restless/serialization/deserializers.py
+++ b/flask_restless/serialization/deserializers.py
@@ -37,7 +37,7 @@ from ..helpers import get_by
 from ..helpers import has_field
 from ..helpers import is_like_list
 from ..helpers import model_for
-from ..helpers import strings_to_datetimes
+from ..helpers import string_to_datetime as to_datetime
 
 
 class Deserializer(object):
@@ -181,7 +181,7 @@ class DefaultDeserializer(Deserializer):
         data.update(data.pop('attributes', {}))
         # Special case: if there are any dates, convert the string form of the
         # date into an instance of the Python ``datetime`` object.
-        data = strings_to_datetimes(model, data)
+        data = dict((k, to_datetime(model, k, v)) for k, v in data.items())
         # Create the new instance by keyword attributes.
         instance = model(**data)
         # Set each relation specified in the links.

--- a/flask_restless/views/resources.py
+++ b/flask_restless/views/resources.py
@@ -28,7 +28,7 @@ from ..helpers import has_field
 from ..helpers import is_like_list
 from ..helpers import is_relationship
 from ..helpers import primary_key_value
-from ..helpers import strings_to_datetimes
+from ..helpers import string_to_datetime
 from ..serialization import DeserializationException
 from ..serialization import SerializationException
 from .base import APIBase
@@ -620,7 +620,8 @@ class API(APIBase):
                 return error_response(400, detail=detail)
         # Special case: if there are any dates, convert the string form of the
         # date into an instance of the Python ``datetime`` object.
-        data = strings_to_datetimes(self.model, data)
+        data = dict((k, string_to_datetime(self.model, k, v))
+                    for k, v in data.items())
         # Finally, update each attribute individually.
         try:
             if data:

--- a/tests/test_creating.py
+++ b/tests/test_creating.py
@@ -73,6 +73,7 @@ class TestCreating(ManagerTestBase):
             date_created = Column(Date)
             author_id = Column(Integer, ForeignKey('person.id'))
             author = relationship('Person')
+            type = Column(Unicode)
 
         class Person(self.Base):
             __tablename__ = 'person'
@@ -864,6 +865,27 @@ class TestCreating(ManagerTestBase):
         keywords = ['deserialize', 'expected', 'type', '"article"', '"person"',
                     'linkage object', 'relationship', '"articles"']
         check_sole_error(response, 409, keywords)
+
+    def test_special_field_names(self):
+        """Test that an attribute can have the name "type".
+
+        For more information, see issue #559.
+
+        """
+        data = {
+            'data': {
+                'type': 'article',
+                'attributes': {
+                    'type': u'fluff'
+                }
+            }
+        }
+        response = self.app.post('/api/article', data=dumps(data))
+        assert response.status_code == 201
+        document = loads(response.data)
+        article = document['data']
+        assert article['type'] == 'article'
+        assert article['attributes']['type'] == u'fluff'
 
 
 class TestProcessors(ManagerTestBase):

--- a/tests/test_updating.py
+++ b/tests/test_updating.py
@@ -74,6 +74,7 @@ class TestUpdating(ManagerTestBase):
             id = Column(Integer, primary_key=True)
             author = relationship('Person', backref=backref('articles'))
             author_id = Column(Integer, ForeignKey('person.id'))
+            type = Column(Unicode)
 
         class Person(self.Base):
             __tablename__ = 'person'
@@ -918,6 +919,28 @@ class TestUpdating(ManagerTestBase):
         check_sole_error(response, 400, ['does not have', 'field', 'foo'])
         assert person.foo != u'bar'
         assert person.foo() == u'foo'
+
+    def test_special_field_names(self):
+        """Test that an attribute can have the name "type".
+
+        For more information, see issue #559.
+
+        """
+        article = self.Article(id=1, type=u'foo')
+        self.session.add(article)
+        self.session.commit()
+        data = {
+            'data': {
+                'type': 'article',
+                'id': '1',
+                'attributes': {
+                    'type': u'bar'
+                }
+            }
+        }
+        response = self.app.patch('/api/article/1', data=dumps(data))
+        assert response.status_code == 204
+        assert article.type == u'bar'
 
 
 class TestProcessors(ManagerTestBase):


### PR DESCRIPTION
This fixes issue #559 and supercedes pull request #561. The `strings_to_datetimes` helper function was left over from an earlier version and was unnecessary. The checks for an attribute being `type` or `links` were pointless, because the `strings_to_datetimes` function was already only looking at the `attributes` dictionary of a resource object.

This commit includes unit tests for creating and updating a resource, and includes a changelog entry.