### PR TITLE
Correctly support models without an "id" column

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Not yet released.
 - :issue:`492`: support JSON API recommended "simple" filtering.
 - :issue:`508`: flush the session before postprocessors, and commit after.
 - :issue:`536`: adds support for single-table inheritance.
+- :issue:`540`: correctly support models that don't have a column named "id".
 - :issue:`546`: adds support for joined table inheritance.
 - :issue:`559`: fixes bug that stripped attributes with JSON API reserved names
   (like "type") when deserializing resources.

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -8,8 +8,8 @@ same.
 If you have defined your models with Flask-SQLAlchemy, first, create your
 :class:`~flask.Flask` object, :class:`~flask_sqlalchemy.SQLAlchemy` object, and
 model classes as usual but with one additional restriction: each model must
-have a primary key column named ``id`` of type
-:class:`~sqlalchemy.types.Integer` or type :class:`~sqlalchemy.types.Unicode`.
+have a primary key column of type either :class:`~sqlalchemy.types.Integer` or
+:class:`~sqlalchemy.types.Unicode`.
 
 .. sourcecode:: python
 

--- a/flask_restless/manager.py
+++ b/flask_restless/manager.py
@@ -595,9 +595,6 @@ class APIManager(object):
         if only is not None and exclude is not None:
             msg = 'Cannot simultaneously specify both `only` and `exclude`'
             raise IllegalArgumentError(msg)
-        if not hasattr(model, 'id'):
-            msg = 'Provided model must have an `id` attribute'
-            raise IllegalArgumentError(msg)
         if collection_name == '':
             msg = 'Collection name must be nonempty'
             raise IllegalArgumentError(msg)

--- a/flask_restless/serialization/serializers.py
+++ b/flask_restless/serialization/serializers.py
@@ -355,7 +355,7 @@ class DefaultSerializer(Serializer):
                 # work than it needs to here.)
                 attributes[key] = serialized_val['data']
         # Get the ID and type of the resource.
-        id_ = attributes.pop('id')
+        id_ = attributes.pop('id', None)
         type_ = collection_name(model)
         # Create the result dictionary and add the attributes.
         result = dict(id=id_, type=type_)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -400,14 +400,6 @@ class TestAPIManager(ManagerTestBase):
             response = func('/api/person')
             assert response.status_code == 405
 
-    def test_missing_id(self):
-        """Tests that calling :meth:`APIManager.create_api` on a model without
-        an ``id`` column raises an exception.
-
-        """
-        with self.assertRaises(IllegalArgumentError):
-            self.manager.create_api(self.Tag)
-
     def test_empty_collection_name(self):
         """Tests that calling :meth:`APIManager.create_api` with an empty
         collection name raises an exception.


### PR DESCRIPTION
Fixes issue #540. Thanks to all those who helped with reporting and offering solutions.