### PR TITLE
Separates PostgreSQL testing from other tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ python:
   # - "pypy3"
 
 addons:
-  # HACK Need to update the installed version of PostgreSQL, because it doesn't
-  # implement all of the network operators (specifically the &&
-  # operator). Travis claims that version 9.4 is installed by default, but it
-  # claims that && is unknown unless this addon is here.
+  # The default Travis build environment uses PostgreSQL 9.1, but some of the
+  # network operators (specifically the && operator) do not exist until version
+  # 9.4, so we manually specify the newer version.
   postgresql: "9.4"
   apt:
     packages:
@@ -51,6 +50,10 @@ install:
   - pip install flake8 coveralls
   # Install Flask-Restless so that it is available for the documentation build.
   - python setup.py install
+
+before_script:
+  # Create the PostgreSQL database for testing PostgreSQL-specific operators.
+  - psql -c 'create database testdb;' -U postgres
 
 script:
   # Code style checks. Flake8 doesn't support Python 2.6.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,2 @@
 -r requirements.txt
 unittest2
-
-# For testing PostgreSQL specific operations...
-testing.postgresql

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -15,13 +15,6 @@ from datetime import datetime
 from datetime import time
 from unittest2 import skip
 
-# This import is unused but is required for testing on PyPy. CPython can
-# use psycopg2, but PyPy can only use psycopg2cffi.
-try:
-    import psycopg2  # noqa
-except ImportError:
-    from psycopg2cffi import compat
-    compat.register()
 from sqlalchemy import Column
 from sqlalchemy import Date
 from sqlalchemy import DateTime
@@ -29,33 +22,14 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import Time
 from sqlalchemy import Unicode
-from sqlalchemy.dialects.postgresql import INET
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
-from testing.postgresql import PostgresqlFactory as PGFactory
 
 from .helpers import check_sole_error
 from .helpers import dumps
 from .helpers import loads
 from .helpers import ManagerTestBase
-
-
-#: The PostgreSQL class used to create a temporary database for testing.
-#:
-#: This class should be instantiated in the setup method of test
-#: classes, and the :class:`Postgresql.stop` method should be called on
-#: teardown.
-#:
-#: This is an optimization designed to speed up the tests that require
-#: PostgreSQL, since it can be extremely slow to initialize a PostgreSQL
-#: database before each test method.
-PostgreSQL = PGFactory(cache_initialized_db=True)
-
-
-def tearDown():
-    """Clears the cache in the :attr:`PostgreSQL` class."""
-    PostgreSQL.clear_cache()
 
 
 class SearchTestBase(ManagerTestBase):
@@ -1196,181 +1170,6 @@ class TestOperators(SearchTestBase):
         response = self.search('/api/person', filters)
         keywords = ['compare', 'value', 'NULL', 'use', 'is_null', 'operator']
         check_sole_error(response, 400, keywords)
-
-
-class TestNetworkOperators(SearchTestBase):
-    """Unit tests for the network address operators in PostgreSQL.
-
-    For more information, see `Network Address Functions and Operators`_
-    in the PostgreSQL documentation.
-
-    .. _Network Address Functions and Operators:
-       http://www.postgresql.org/docs/current/interactive/functions-net.html
-
-    """
-
-    def setUp(self):
-        super(TestNetworkOperators, self).setUp()
-
-        class Network(self.Base):
-            __tablename__ = 'network'
-            id = Column(Integer, primary_key=True)
-            address = Column(INET)
-
-        self.Network = Network
-        self.Base.metadata.create_all()
-        self.manager.create_api(Network)
-
-    def tearDown(self):
-        """Closes the database and removes the temporary directory in
-        which it lives.
-
-        """
-        super(TestNetworkOperators, self).tearDown()
-        self.database.stop()
-
-    # We know this method will be called by `setUp()` in the superclass,
-    # so we can set up the temporary database here.
-    def database_uri(self):
-        """Creates a PostgreSQL database and returns its connection URI."""
-        #: The PostgreSQL database used by the test methods in this class.
-        #:
-        #: This attribute stores a
-        #: :class:`~testing.postgresql.Postgresql` object, which must be
-        #: stopped in the :meth:`.tearDown` method.
-        self.database = PostgreSQL()
-
-        return self.database.url()
-
-    def test_is_not_equal(self):
-        """Test for the ``<>`` ("is not equal") operator.
-
-        For example:
-
-        .. sourcecode:: postgresql
-
-           inet '192.168.1.5' <> inet '192.168.1.4'
-
-        """
-        network1 = self.Network(id=1, address='192.168.1.5')
-        network2 = self.Network(id=2, address='192.168.1.4')
-        self.session.add_all([network1, network2])
-        self.session.commit()
-        filters = [dict(name='address', op='<>', val='192.168.1.4')]
-        response = self.search('/api/network', filters)
-        document = loads(response.data)
-        networks = document['data']
-        assert ['1'] == sorted(network['id'] for network in networks)
-
-    def test_is_contained_by(self):
-        """Test for the ``<<`` ("is contained by") operator.
-
-        For example:
-
-        .. sourcecode:: postgresql
-
-           inet '192.168.1.5' << inet '192.168.1/24'
-
-        """
-        network1 = self.Network(id=1, address='192.168.1.5')
-        network2 = self.Network(id=2, address='192.168.2.1')
-        self.session.add_all([network1, network2])
-        self.session.commit()
-        filters = [dict(name='address', op='<<', val='192.168.1/24')]
-        response = self.search('/api/network', filters)
-        document = loads(response.data)
-        networks = document['data']
-        assert ['1'] == sorted(network['id'] for network in networks)
-
-    def test_is_contained_by_or_equals(self):
-        """Test for the ``<<=`` ("is contained by or equals") operator.
-
-        For example:
-
-        .. sourcecode:: postgresql
-
-           inet '192.168.1/24' <<= inet '192.168.1/24'
-
-        """
-        network1 = self.Network(id=1, address='192.168.1/24')
-        network2 = self.Network(id=2, address='192.168.1.5')
-        network3 = self.Network(id=3, address='192.168.2.1')
-        self.session.add_all([network1, network2, network3])
-        self.session.commit()
-        filters = [dict(name='address', op='<<=', val='192.168.1/24')]
-        response = self.search('/api/network', filters)
-        document = loads(response.data)
-        networks = document['data']
-        assert ['1', '2'] == sorted(network['id'] for network in networks)
-
-    def test_contains(self):
-        """Test for the ``>>`` ("contains") operator.
-
-        For example:
-
-        .. sourcecode:: postgresql
-
-           inet '192.168.1/24' >> inet '192.168.1.5'
-
-        """
-        network1 = self.Network(id=1, address='192.168.1/24')
-        network2 = self.Network(id=2, address='192.168.2/24')
-        self.session.add_all([network1, network2])
-        self.session.commit()
-        filters = [dict(name='address', op='>>', val='192.168.1.5')]
-        response = self.search('/api/network', filters)
-        document = loads(response.data)
-        networks = document['data']
-        assert ['1'] == sorted(network['id'] for network in networks)
-
-    def test_contains_or_equals(self):
-        """Test for the ``>>=`` ("contains or equals") operator.
-
-        For example:
-
-        .. sourcecode:: postgresql
-
-           inet '192.168.1/24' >>= inet '192.168.1/24'
-
-        """
-        network1 = self.Network(id=1, address='192.168.1/24')
-        network2 = self.Network(id=2, address='192.168/16')
-        network3 = self.Network(id=3, address='192.168.2/24')
-        self.session.add_all([network1, network2, network3])
-        self.session.commit()
-        filters = [dict(name='address', op='>>=', val='192.168.1/24')]
-        response = self.search('/api/network', filters)
-        document = loads(response.data)
-        networks = document['data']
-        assert ['1', '2'] == sorted(network['id'] for network in networks)
-
-    def test_contains_or_is_contained_by(self):
-        """Test for the ``&&`` ("contains or is contained by") operator.
-
-        .. warning::
-
-           This operation is only available in PostgreSQL 9.4 or later.
-
-        For example:
-
-        .. sourcecode:: postgresql
-
-           inet '192.168.1/24' && inet '192.168.1.80/28'
-
-        """
-        # network1 contains the queried subnet
-        network1 = self.Network(id=1, address='192.168.1/24')
-        # network2 is contained by the queried subnet
-        network2 = self.Network(id=2, address='192.168.1.81/28')
-        # network3 is neither
-        network3 = self.Network(id=3, address='192.168.2.1')
-        self.session.add_all([network1, network2, network3])
-        self.session.commit()
-        filters = [dict(name='address', op='&&', val='192.168.1.80/28')]
-        response = self.search('/api/network', filters)
-        document = loads(response.data)
-        networks = document['data']
-        assert ['1', '2'] == sorted(network['id'] for network in networks)
 
 
 class TestAssociationProxy(SearchTestBase):

--- a/tests/test_filtering_postgresql.py
+++ b/tests/test_filtering_postgresql.py
@@ -1,0 +1,200 @@
+# test_filtering_postgresql.py - filtering tests for PostgreSQL
+#
+# Copyright 2011 Lincoln de Sousa <lincoln@comum.org>.
+# Copyright 2012, 2013, 2014, 2015, 2016 Jeffrey Finkelstein
+#           <jeffrey.finkelstein@gmail.com> and contributors.
+#
+# This file is part of Flask-Restless.
+#
+# Flask-Restless is distributed under both the GNU Affero General Public
+# License version 3 and under the 3-clause BSD license. For more
+# information, see LICENSE.AGPL and LICENSE.BSD.
+"""Unit tests for PostgreSQL-specific filtering operators."""
+
+# The psycopg2cffi import is required for testing on PyPy. CPython can
+# use psycopg2, but PyPy can only use psycopg2cffi.
+try:
+    import psycopg2  # noqa
+except ImportError:
+    from psycopg2cffi import compat
+    compat.register()
+from sqlalchemy import Column
+from sqlalchemy import Integer
+from sqlalchemy.dialects.postgresql import INET
+from sqlalchemy.exc import OperationalError
+
+from .helpers import loads
+from .test_filtering import SearchTestBase
+
+
+class TestNetworkOperators(SearchTestBase):
+    """Unit tests for the network address operators in PostgreSQL.
+
+    For more information, see `Network Address Functions and Operators`_
+    in the PostgreSQL documentation.
+
+    .. _Network Address Functions and Operators:
+       http://www.postgresql.org/docs/current/interactive/functions-net.html
+
+    """
+
+    def setUp(self):
+        super(TestNetworkOperators, self).setUp()
+
+        class Network(self.Base):
+            __tablename__ = 'network'
+            id = Column(Integer, primary_key=True)
+            address = Column(INET)
+
+        self.Network = Network
+        # This try/except skips the tests if we are unable to create the
+        # tables in the PostgreSQL database.
+        try:
+            self.Base.metadata.create_all()
+        except OperationalError as e:
+            raise e
+            # self.skipTest('error creating tables in PostgreSQL database')
+        self.manager.create_api(Network)
+
+    def database_uri(self):
+        """Return a PostgreSQL connection URI.
+
+        Since this test case is for operators specific to PostgreSQL, we
+        return a PostgreSQL connection URI. The particular
+        Python-to-PostgreSQL adapter we are using is currently
+        `Psycopg`_.
+
+        .. _Psycopg: http://initd.org/psycopg/
+
+        """
+        return 'postgresql+psycopg2://postgres@localhost:5432/testdb'
+
+    def test_is_not_equal(self):
+        """Test for the ``<>`` ("is not equal") operator.
+
+        For example:
+
+        .. sourcecode:: postgresql
+
+           inet '192.168.1.5' <> inet '192.168.1.4'
+
+        """
+        network1 = self.Network(id=1, address='192.168.1.5')
+        network2 = self.Network(id=2, address='192.168.1.4')
+        self.session.add_all([network1, network2])
+        self.session.commit()
+        filters = [dict(name='address', op='<>', val='192.168.1.4')]
+        response = self.search('/api/network', filters)
+        document = loads(response.data)
+        networks = document['data']
+        assert ['1'] == sorted(network['id'] for network in networks)
+
+    def test_is_contained_by(self):
+        """Test for the ``<<`` ("is contained by") operator.
+
+        For example:
+
+        .. sourcecode:: postgresql
+
+           inet '192.168.1.5' << inet '192.168.1/24'
+
+        """
+        network1 = self.Network(id=1, address='192.168.1.5')
+        network2 = self.Network(id=2, address='192.168.2.1')
+        self.session.add_all([network1, network2])
+        self.session.commit()
+        filters = [dict(name='address', op='<<', val='192.168.1/24')]
+        response = self.search('/api/network', filters)
+        document = loads(response.data)
+        networks = document['data']
+        assert ['1'] == sorted(network['id'] for network in networks)
+
+    def test_is_contained_by_or_equals(self):
+        """Test for the ``<<=`` ("is contained by or equals") operator.
+
+        For example:
+
+        .. sourcecode:: postgresql
+
+           inet '192.168.1/24' <<= inet '192.168.1/24'
+
+        """
+        network1 = self.Network(id=1, address='192.168.1/24')
+        network2 = self.Network(id=2, address='192.168.1.5')
+        network3 = self.Network(id=3, address='192.168.2.1')
+        self.session.add_all([network1, network2, network3])
+        self.session.commit()
+        filters = [dict(name='address', op='<<=', val='192.168.1/24')]
+        response = self.search('/api/network', filters)
+        document = loads(response.data)
+        networks = document['data']
+        assert ['1', '2'] == sorted(network['id'] for network in networks)
+
+    def test_contains(self):
+        """Test for the ``>>`` ("contains") operator.
+
+        For example:
+
+        .. sourcecode:: postgresql
+
+           inet '192.168.1/24' >> inet '192.168.1.5'
+
+        """
+        network1 = self.Network(id=1, address='192.168.1/24')
+        network2 = self.Network(id=2, address='192.168.2/24')
+        self.session.add_all([network1, network2])
+        self.session.commit()
+        filters = [dict(name='address', op='>>', val='192.168.1.5')]
+        response = self.search('/api/network', filters)
+        document = loads(response.data)
+        networks = document['data']
+        assert ['1'] == sorted(network['id'] for network in networks)
+
+    def test_contains_or_equals(self):
+        """Test for the ``>>=`` ("contains or equals") operator.
+
+        For example:
+
+        .. sourcecode:: postgresql
+
+           inet '192.168.1/24' >>= inet '192.168.1/24'
+
+        """
+        network1 = self.Network(id=1, address='192.168.1/24')
+        network2 = self.Network(id=2, address='192.168/16')
+        network3 = self.Network(id=3, address='192.168.2/24')
+        self.session.add_all([network1, network2, network3])
+        self.session.commit()
+        filters = [dict(name='address', op='>>=', val='192.168.1/24')]
+        response = self.search('/api/network', filters)
+        document = loads(response.data)
+        networks = document['data']
+        assert ['1', '2'] == sorted(network['id'] for network in networks)
+
+    def test_contains_or_is_contained_by(self):
+        """Test for the ``&&`` ("contains or is contained by") operator.
+
+        .. warning::
+
+           This operation is only available in PostgreSQL 9.4 or later.
+
+        For example:
+
+        .. sourcecode:: postgresql
+
+           inet '192.168.1/24' && inet '192.168.1.80/28'
+
+        """
+        # network1 contains the queried subnet
+        network1 = self.Network(id=1, address='192.168.1/24')
+        # network2 is contained by the queried subnet
+        network2 = self.Network(id=2, address='192.168.1.81/28')
+        # network3 is neither
+        network3 = self.Network(id=3, address='192.168.2.1')
+        self.session.add_all([network1, network2, network3])
+        self.session.commit()
+        filters = [dict(name='address', op='&&', val='192.168.1.80/28')]
+        response = self.search('/api/network', filters)
+        document = loads(response.data)
+        networks = document['data']
+        assert ['1', '2'] == sorted(network['id'] for network in networks)


### PR DESCRIPTION
This pull request removes the postgres testing from the other tests so that it is easier to skip if desired. This also removes the test dependency on `testing.postgresql` in favor of just creating the database in the Travis configuration directly (using the technique recommended by Travis itself).