### PR TITLE
Give a clearer error message if id is not a string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,8 @@ Not yet released.
 - :issue:`481,488`: added negation (``not``) operator for search.
 - :issue:`492`: support JSON API recommended "simple" filtering.
 - :issue:`508`: flush the session before postprocessors, and commit after.
+- :issue:`534`: when updating a resource, give a clearer error message if the
+  resource ID in the JSON document is not a JSON string.
 - :issue:`536`: adds support for single-table inheritance.
 - :issue:`540`: correctly support models that don't have a column named "id".
 - :issue:`546`: adds support for joined table inheritance.

--- a/tests/test_updating.py
+++ b/tests/test_updating.py
@@ -942,6 +942,25 @@ class TestUpdating(ManagerTestBase):
         assert response.status_code == 204
         assert article.type == u'bar'
 
+    def test_integer_id_error_message(self):
+        """Test that an integer ID in the JSON request yields an error.
+
+        For more information, see GitHub issue #534.
+
+        """
+        person = self.Person(id=1)
+        self.session.add(person)
+        self.session.commit()
+        data = {
+            'data': {
+                'type': 'person',
+                'id': 1,
+            }
+        }
+        response = self.app.patch('/api/person/1', data=dumps(data))
+        check_sole_error(response, 409, ['"id" element', 'resource object',
+                                         'must be a JSON string'])
+
 
 class TestProcessors(ManagerTestBase):
     """Tests for pre- and postprocessors."""


### PR DESCRIPTION
This commit causes the server to give a clearer error message if the
resource ID given in the resource object on an update request is not a
string.

This fixes issue #534.