### PR TITLE
Removes duplicate Content-Type headers in response

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,12 +21,15 @@ Not yet released.
 - Changes serialization/deserialization to class-based implementation instead
   of a function-based implementation. This also adds support for serialization
   of heterogeneous collections.
+- Removes `mimerender`_ as a dependency.
 - :issue:`7`: allows filtering before function evaluation.
 - :issue:`49`: deserializers now expect a complete JSON API document.
 - :issue:`200`: be smarter about determining the ``collection_name`` for
   polymorphic models defined with single-table inheritance.
 - :issue:`253`: don't assign to callable attributes of models.
 - :issue:`268`: adds top-level endpoint that exposes API schema.
+- :issue:`479`: removes duplicate (and sometimes conflicting)
+  :http:header:`Content-Type` header in responses.
 - :issue:`481,488`: added negation (``not``) operator for search.
 - :issue:`492`: support JSON API recommended "simple" filtering.
 - :issue:`508`: flush the session before postprocessors, and commit after.
@@ -204,8 +207,7 @@ Released on April 6, 2014.
 - :issue:`29`: replace custom ``jsonify_status_code`` function with built-in support
   for ``return jsonify(), status_code`` style return statements (new in Flask
   0.9).
-- :issue:`51`: Use `mimerender <http://mimerender.readthedocs.org>`_ to render
-  dictionaries to JSON format.
+- :issue:`51`: Use `mimerender`_ to render dictionaries to JSON format.
 - :issue:`247`: adds support for making :http:method:`post` requests to dictionary-like
   association proxies.
 - :issue:`249`: returns :http:statuscode:`404` if a search reveals no matching results.
@@ -223,6 +225,8 @@ Released on April 6, 2014.
   are sent to the server.
 - :issue:`286`: speed up paginated responses by using optimized count() function.
 - :issue:`293`: allows :class:`sqlalchemy.types.Time` fields in JSON responses.
+
+.. _mimerender: https://mimerender.readthedocs.io
 
 Version 0.12.1
 ~~~~~~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,7 +15,6 @@ installed if you use ``pip``):
 
 * `Flask`_ version 0.10 or greater
 * `SQLAlchemy`_ version 0.8 or greater
-* `mimerender`_ version 0.5.2 or greater
 * `python-dateutil`_ version strictly greater than 2.2
 * `Flask-SQLAlchemy`_, *only if* you want to define your models using
   Flask-SQLAlchemy (which we recommend)
@@ -24,6 +23,5 @@ installed if you use ``pip``):
 .. _GitHub: https://github.com/jfinkels/flask-restless
 .. _Flask: http://flask.pocoo.org
 .. _SQLAlchemy: https://sqlalchemy.org
-.. _mimerender: https://mimerender.readthedocs.org
 .. _python-dateutil: http://labix.org/python-dateutil
 .. _Flask-SQLAlchemy: https://packages.python.org/Flask-SQLAlchemy

--- a/flask_restless/__init__.py
+++ b/flask_restless/__init__.py
@@ -30,7 +30,7 @@ from .serialization import MultipleExceptions
 from .serialization import SerializationException
 from .serialization import simple_serialize
 from .serialization import simple_serialize_many
-from .views import CONTENT_TYPE
+from .views import JSONAPI_MIMETYPE
 from .views import ProcessingException
 
 #: The current version of this extension.
@@ -42,11 +42,11 @@ __version__ = '1.0.0b2-dev'
 __all__ = [
     'APIManager',
     'collection_name',
-    'CONTENT_TYPE',
     'DefaultDeserializer',
     'DefaultSerializer',
     'DeserializationException',
     'IllegalArgumentError',
+    'JSONAPI_MIMETYPE',
     'model_for',
     'MultipleExceptions',
     'primary_key_for',

--- a/flask_restless/views/__init__.py
+++ b/flask_restless/views/__init__.py
@@ -17,7 +17,7 @@ The classes :class:`API`, :class:`FunctionAPI`, and
 that do most of the work.
 
 """
-from .base import CONTENT_TYPE
+from .base import JSONAPI_MIMETYPE
 from .base import ProcessingException
 from .base import SchemaView
 from .resources import API
@@ -26,8 +26,8 @@ from .function import FunctionAPI
 
 __all__ = [
     'API',
-    'CONTENT_TYPE',
     'FunctionAPI',
+    'JSONAPI_MIMETYPE',
     'ProcessingException',
     'RelationshipAPI',
     'SchemaView',

--- a/flask_restless/views/function.py
+++ b/flask_restless/views/function.py
@@ -25,6 +25,7 @@ from ..search import create_filters
 from ..search import FilterParsingError
 from ..search import FilterCreationError
 from .base import error_response
+from .base import jsonpify
 from .base import ModelView
 from .base import SingleKeyError
 
@@ -109,7 +110,7 @@ class FunctionAPI(ModelView):
 
         # If there are no functions to execute, simply return the empty list.
         if not functions:
-            return dict(data=[])
+            return jsonpify({'data': []})
 
         # Create the function query.
         try:
@@ -153,4 +154,4 @@ class FunctionAPI(ModelView):
             detail = 'unknown function "{0}"'.format(bad_function)
             return error_response(400, cause=exception, detail=detail)
 
-        return dict(data=result)
+        return jsonpify({'data': result})

--- a/flask_restless/views/relationships.py
+++ b/flask_restless/views/relationships.py
@@ -28,6 +28,7 @@ from .base import APIBase
 from .base import error
 from .base import error_response
 from .base import errors_response
+from .base import jsonpify
 from .base import SingleKeyError
 
 
@@ -184,7 +185,7 @@ class RelationshipAPI(APIBase):
         for postprocessor in self.postprocessors['POST_RELATIONSHIP']:
             postprocessor()
         self.session.commit()
-        return {}, 204
+        return jsonpify({}), 204
 
     def patch(self, resource_id, relation_name):
         """Updates to a to-one or to-many relationship.
@@ -309,7 +310,7 @@ class RelationshipAPI(APIBase):
         for postprocessor in self.postprocessors['PATCH_RELATIONSHIP']:
             postprocessor()
         self.session.commit()
-        return {}, 204
+        return jsonpify({}), 204
 
     def delete(self, resource_id, relation_name):
         """Deletes resources from a to-many relationship.
@@ -395,4 +396,4 @@ class RelationshipAPI(APIBase):
         if not was_deleted:
             detail = 'There was no instance to delete'
             return error_response(404, detail=detail)
-        return {}, 204
+        return jsonpify({}), 204

--- a/flask_restless/views/resources.py
+++ b/flask_restless/views/resources.py
@@ -38,6 +38,7 @@ from .base import error
 from .base import error_response
 from .base import errors_from_serialization_exceptions
 from .base import errors_response
+from .base import jsonpify
 from .base import MultipleExceptions
 from .base import SingleKeyError
 from .helpers import changes_on_update
@@ -442,7 +443,7 @@ class API(APIBase):
         if not was_deleted:
             detail = 'There was no instance to delete.'
             return error_response(404, detail=detail)
-        return {}, 204
+        return jsonpify({}), 204
 
     def post(self):
         """Creates a new resource based on request data.
@@ -507,7 +508,7 @@ class API(APIBase):
         for postprocessor in self.postprocessors['POST_RESOURCE']:
             postprocessor(result=result)
         self.session.commit()
-        return result, status, headers
+        return jsonpify(result), status, headers
 
     def _update_instance(self, instance, data, resource_id):
         """Updates the attributes and relationships of the specified instance
@@ -725,4 +726,4 @@ class API(APIBase):
         for postprocessor in self.postprocessors['PATCH_RESOURCE']:
             postprocessor(result=result)
         self.session.commit()
-        return result, status
+        return jsonpify(result), status

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ flask>=0.10
 flask-sqlalchemy>=0.10
 sqlalchemy>=0.8
 python-dateutil>2.2
-mimerender>=0.5.2

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,7 @@ VERSION_RE = r"^__version__ = ['\"]([^'\"]*)['\"]"
 
 #: The installation requirements for Flask-Restless. Flask-SQLAlchemy is not
 #: required, so the user must install it explicitly.
-REQUIREMENTS = ['flask>=0.10', 'sqlalchemy>=0.8', 'python-dateutil>2.2',
-                'mimerender>=0.5.2']
+REQUIREMENTS = ['flask>=0.10', 'sqlalchemy>=0.8', 'python-dateutil>2.2']
 
 #: The absolute path to this file.
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,10 +42,10 @@ from sqlalchemy.types import TypeDecorator
 
 from flask_restless import APIManager
 from flask_restless import collection_name
-from flask_restless import CONTENT_TYPE
 from flask_restless import DefaultSerializer
 from flask_restless import DefaultDeserializer
 from flask_restless import DeserializationException
+from flask_restless import JSONAPI_MIMETYPE
 from flask_restless import model_for
 from flask_restless import primary_key_for
 from flask_restless import SerializationException
@@ -214,7 +214,7 @@ def force_content_type_jsonapi(test_client):
                 kw['headers'] = dict()
             headers = kw['headers']
             if 'content_type' not in kw and 'Content-Type' not in headers:
-                kw['content_type'] = CONTENT_TYPE
+                kw['content_type'] = JSONAPI_MIMETYPE
             return func(*args, **kw)
         return new_func
 

--- a/tests/test_creating.py
+++ b/tests/test_creating.py
@@ -38,7 +38,7 @@ from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 
 from flask_restless import APIManager
-from flask_restless import CONTENT_TYPE
+from flask_restless import JSONAPI_MIMETYPE
 from flask_restless import DefaultDeserializer
 from flask_restless import DefaultSerializer
 from flask_restless import ProcessingException
@@ -201,9 +201,9 @@ class TestCreating(ManagerTestBase):
         """
         data = dict(data=dict(type='person'))
         response = self.app.post('/api/person', data=dumps(data),
-                                 content_type=CONTENT_TYPE)
+                                 content_type=JSONAPI_MIMETYPE)
         assert response.status_code == 201
-        assert response.headers['Content-Type'] == CONTENT_TYPE
+        assert response.headers['Content-Type'] == JSONAPI_MIMETYPE
 
     def test_no_content_type(self):
         """Tests that the server responds with :http:status:`415` if the
@@ -214,7 +214,7 @@ class TestCreating(ManagerTestBase):
         response = self.app.post('/api/person', data=dumps(data),
                                  content_type=None)
         assert response.status_code == 415
-        assert response.headers['Content-Type'] == CONTENT_TYPE
+        assert response.headers['Content-Type'] == JSONAPI_MIMETYPE
 
     def test_msie8(self):
         """Tests for compatibility with Microsoft Internet Explorer 8.

--- a/tests/test_jsonapi/test_server_responsibilities.py
+++ b/tests/test_jsonapi/test_server_responsibilities.py
@@ -25,7 +25,7 @@ from sqlalchemy import Column
 from sqlalchemy import Unicode
 from sqlalchemy import Integer
 
-from flask_restless import CONTENT_TYPE
+from flask_restless import JSONAPI_MIMETYPE
 
 from ..helpers import check_sole_error
 from ..helpers import dumps
@@ -66,7 +66,7 @@ class TestServerResponsibilities(ManagerTestBase):
 
         """
         response = self.app.get('/api/person')
-        assert response.mimetype == CONTENT_TYPE
+        assert response.mimetype == JSONAPI_MIMETYPE
 
     def test_post_content_type(self):
         """"Tests that a response to a :http:method:`post` request has
@@ -85,7 +85,7 @@ class TestServerResponsibilities(ManagerTestBase):
         """
         data = {'data': {'type': 'person'}}
         response = self.app.post('/api/person', data=dumps(data))
-        assert response.mimetype == CONTENT_TYPE
+        assert response.mimetype == JSONAPI_MIMETYPE
 
     @skip('we currently do not support updates that have side-effects')
     def test_patch_content_type(self):
@@ -113,7 +113,7 @@ class TestServerResponsibilities(ManagerTestBase):
         }
         # TODO Need to make a request that has side-effects.
         response = self.app.patch('/api/person/1', data=dumps(data))
-        assert response.mimetype == CONTENT_TYPE
+        assert response.mimetype == JSONAPI_MIMETYPE
 
     def test_no_response_media_type_params(self):
         """"Tests that a server responds with :http:status:`415` if any
@@ -131,7 +131,7 @@ class TestServerResponsibilities(ManagerTestBase):
                 'type': 'person',
             }
         }
-        headers = {'Content-Type': '{0}; version=1'.format(CONTENT_TYPE)}
+        headers = {'Content-Type': '{0}; version=1'.format(JSONAPI_MIMETYPE)}
         response = self.app.post('/api/person', data=dumps(data),
                                  headers=headers)
         check_sole_error(response, 415, ['Content-Type',
@@ -166,7 +166,7 @@ class TestServerResponsibilities(ManagerTestBase):
            http://jsonapi.org/format/#content-negotiation-servers
 
         """
-        headers = {'Accept': CONTENT_TYPE}
+        headers = {'Accept': JSONAPI_MIMETYPE}
         response = self.app.get('/api/person', headers=headers)
         assert response.status_code == 200
         document = loads(response.data)
@@ -184,6 +184,6 @@ class TestServerResponsibilities(ManagerTestBase):
            http://jsonapi.org/format/#content-negotiation-servers
 
         """
-        headers = {'Accept': '{0}; q=.8, {0}; q=.9'.format(CONTENT_TYPE)}
+        headers = {'Accept': '{0}; q=.8, {0}; q=.9'.format(JSONAPI_MIMETYPE)}
         response = self.app.get('/api/person', headers=headers)
         check_sole_error(response, 406, ['Accept', 'media type parameter'])

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -15,7 +15,7 @@ from unittest2 import skip
 from sqlalchemy import Column
 from sqlalchemy import Integer
 
-from flask_restless import CONTENT_TYPE
+from flask_restless import JSONAPI_MIMETYPE
 
 from .helpers import loads
 from .helpers import ManagerTestBase
@@ -58,4 +58,4 @@ class TestMetadata(ManagerTestBase):
         response = self.app.get('/api/person')
         document = loads(response.data)
         meta = document['meta']
-        assert meta['Content-Type'] == CONTENT_TYPE
+        assert meta['Content-Type'] == JSONAPI_MIMETYPE

--- a/tests/test_server_responsibilities.py
+++ b/tests/test_server_responsibilities.py
@@ -47,3 +47,34 @@ class TestServerResponsibilities(ManagerTestBase):
         person = document['data']
         self.assertEqual(person['id'], '1')
         self.assertEqual(person['type'], 'person')
+
+    def test_no_duplicate_headers(self):
+        """Test that each header appears only once in the response.
+
+        For more information, see GitHub issue #479.
+
+        """
+        response = self.app.get('/api/person')
+        self.assertIn('Content-Type', response.headers)
+        self.assertIn('Link', response.headers)
+        headers_list = response.headers.to_wsgi_list()
+        # TODO In Python 2.7+, this should be a set comprehension.
+        headers_set = set(k for k, v in headers_list)
+        self.assertEqual(len(headers_list), len(headers_set))
+
+    def test_jsonp_content_type(self):
+        """Test that the Content-Type for JSONP is application/javascript."""
+        response = self.app.get('/api/person?callback=foo')
+        self.assertEqual(response.content_type, 'application/javascript')
+
+    def test_jsonp_one_content_type(self):
+        """Test that a JSONP response has only one Content-Type header.
+
+        For more information, see GitHub issue #479.
+
+        """
+        response = self.app.get('/api/person?callback=foo')
+        headers_list = response.headers.to_wsgi_list()
+        # TODO In Python 2.7+, this should be a set comprehension.
+        headers_set = set(k for k, v in headers_list)
+        self.assertEqual(len(headers_list), len(headers_set))

--- a/tests/test_updating.py
+++ b/tests/test_updating.py
@@ -43,7 +43,7 @@ from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 
 from flask_restless import APIManager
-from flask_restless import CONTENT_TYPE
+from flask_restless import JSONAPI_MIMETYPE
 from flask_restless import ProcessingException
 
 from .helpers import BetterJSONEncoder as JSONEncoder
@@ -267,9 +267,9 @@ class TestUpdating(ManagerTestBase):
         self.session.commit()
         data = dict(data=dict(type='person', id='1'))
         response = self.app.patch('/api/person/1', data=dumps(data),
-                                  content_type=CONTENT_TYPE)
+                                  content_type=JSONAPI_MIMETYPE)
         assert response.status_code == 204
-        assert response.headers['Content-Type'] == CONTENT_TYPE
+        assert response.headers['Content-Type'] == JSONAPI_MIMETYPE
 
     def test_no_content_type(self):
         """Tests that the server responds with :http:status:`415` if the
@@ -283,7 +283,7 @@ class TestUpdating(ManagerTestBase):
         response = self.app.patch('/api/person/1', data=dumps(data),
                                   content_type=None)
         assert response.status_code == 415
-        assert response.headers['Content-Type'] == CONTENT_TYPE
+        assert response.headers['Content-Type'] == JSONAPI_MIMETYPE
 
     def test_msie8(self):
         """Tests for compatibility with Microsoft Internet Explorer 8.


### PR DESCRIPTION
This commit also eliminates mimerender as a dependency.

Fixes issue #479.