### PR TITLE
Removes Sphinx deprecated LaTeX options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,12 @@ before_script:
   - psql -c 'create database testdb;' -U postgres
 
 script:
-  # Documentation build checks.
-  - sphinx-build -n -W docs/ build/sphinx/html/
+  # Documentation build checks. Sphinx 1.5 only supports Python version 2.7
+  # and 3.4+, so don't build the documentation on those versions.
+  - |
+    if [[ "$TRAVIS_PYTHON_VERSION" != "2.6" && "$TRAVIS_PYTHON_VERSION" != "3.3" ]]; then
+      sphinx-build -n -W docs/ build/sphinx/html/
+    fi
   # Unit tests.
   - coverage run --source=flask_restless setup.py test
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,16 +233,12 @@ latex_documents = [
 # If false, no module index is generated.
 latex_domain_indices = False
 
-# If false, no module index is generated.
-latex_use_modindex = False
-
 latex_elements = {
     'fontpkg':      r'\usepackage{mathpazo}',
     'papersize':    'a4paper',
     'pointsize':    '12pt',
     'preamble':     r'\usepackage{flaskstyle}'
 }
-latex_use_parts = True
 
 latex_additional_files = ['flaskstyle.sty', 'logo.png']
 

--- a/docs/flaskstyle.sty
+++ b/docs/flaskstyle.sty
@@ -21,7 +21,7 @@
       %\sphinxlogo%
       {\center
         \vspace*{3cm}
-      	\includegraphics{logo.pdf}
+        \includegraphics{logo.png}
         \vspace{3cm}
 	\par
         {\rm\Huge \@title \par}%


### PR DESCRIPTION
Removes some deprecated options for the LaTeX builder in Sphinx 1.5. Also corrects an incorrect reference to the logo file to make the LaTeX documentation build without error.