### PR TITLE
Allows registering a custom operator for filters

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Not yet released.
 - :issue:`559`: fixes bug that stripped attributes with JSON API reserved names
   (like "type") when deserializing resources.
 - :issue:`583`: fixes failing tests when using simplejson.
+- :issue:`590`: allows user to specify a custom operator for filters.
 - :issue:`599`: fixes `unicode` bug using :func:`!urlparse.urljoin` with the
   `future`_ library in resource serialization.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,12 @@ The API Manager class
 .. autoclass:: IllegalArgumentError
 
 
+Search helper functions
+-----------------------
+
+.. autofunction:: register_operator
+
+
 Global helper functions
 -----------------------
 

--- a/docs/filtering.rst
+++ b/docs/filtering.rst
@@ -207,6 +207,34 @@ Flask-Restless also understands the `PostgreSQL network address operators`_
 .. _SQLAlchemy column operators: https://docs.sqlalchemy.org/en/latest/core/expression_api.html#sqlalchemy.sql.operators.ColumnOperators
 .. _PostgreSQL network address operators: https://www.postgresql.org/docs/current/static/functions-net.html
 
+
+Custom operators
+----------------
+
+You can use the :func:`~flask_restless.register_operator` function to extend
+the set of known operators::
+
+    from flask_restless import register_operator
+
+    # Create a custom "greater than" implementation.
+    register_operator('my_gt', lambda x, y: x - y > 0)
+
+Then the client makes a request with a filter object whose ``op`` element is
+the name of this operator:
+
+.. sourcecode:: http
+
+   GET /api/person?filter[objects]=[{"name":"age","op":"my_gt","val":18}] HTTP/1.1
+   Host: example.com
+   Accept: application/vnd.api+json
+
+You can also override existing operators by setting the name of your operator
+to be the name of a existing operator; the built-in operators are listed in
+the :ref:`previous section <operators>`::
+
+    register_operator('gt', lambda x, y: x - y > 0)
+
+
 Simpler filtering
 -----------------
 

--- a/flask_restless/__init__.py
+++ b/flask_restless/__init__.py
@@ -30,6 +30,7 @@ from .serialization import MultipleExceptions
 from .serialization import SerializationException
 from .serialization import simple_serialize
 from .serialization import simple_serialize_many
+from .search import register_operator
 from .views import JSONAPI_MIMETYPE
 from .views import ProcessingException
 
@@ -51,6 +52,7 @@ __all__ = [
     'MultipleExceptions',
     'primary_key_for',
     'ProcessingException',
+    'register_operator',
     'SerializationException',
     'serializer_for',
     'simple_serialize',

--- a/flask_restless/search/__init__.py
+++ b/flask_restless/search/__init__.py
@@ -24,16 +24,19 @@ are the exceptions that may be raised by the func:`search` and
 :func:`create_filters` functions.
 
 """
-from .filters import FilterCreationError
-from .filters import FilterParsingError
 from .drivers import create_filters
 from .drivers import search
 from .drivers import search_relationship
+from .filters import FilterCreationError
+from .filters import FilterParsingError
+from .operators import register_operator
+
 
 __all__ = [
     'create_filters',
     'FilterCreationError',
     'FilterParsingError',
+    'register_operator',
     'search',
     'search_relationship',
 ]

--- a/flask_restless/search/operators.py
+++ b/flask_restless/search/operators.py
@@ -170,6 +170,24 @@ OPERATORS = {
 }
 
 
+def register_operator(name, op):
+    """Register an operator so the system can create expressions involving it.
+
+    `name` is a string naming the operator and `op` is a function that
+    takes up to two arguments as input. If the name provided is one of
+    the built-in operators (see :ref:`operators`), it will override the
+    default behavior of that operator. For example, calling ::
+
+        register_operator('gt', myfunc)
+
+    will cause ``myfunc()`` to be invoked in the SQLAlchemy expression
+    created for this operator instead of the default "greater than"
+    operator.
+
+    """
+    OPERATORS[name] = op
+
+
 def create_operation(arg1, operator, arg2):
     """Creates a SQLAlchemy expression for the given operation.
 


### PR DESCRIPTION
Simpler version of pull request #590, which allows registering a custom operator for use in filtering. This pull request includes one test and user-facing documentation.