### PR TITLE
URL encodes first, last, prev, and next links.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -286,9 +286,9 @@ class FlaskTestBase(TestCase):
         app = Flask(__name__)
         app.config['DEBUG'] = True
         app.config['TESTING'] = True
-        # This is required by `manager.url_for()` in order to construct
-        # absolute URLs.
-        app.config['SERVER_NAME'] = 'localhost'
+        # The SERVER_NAME is required by `manager.url_for()` in order to
+        # construct absolute URLs.
+        app.config['SERVER_NAME'] = 'localhost:5000'
         app.logger.disabled = True
         self.flaskapp = app
 


### PR DESCRIPTION
Previously, Flask-Restless was not URL encoding the `first`, `last`,
`next`, and `prev` pagination links in the response JSON document. This
commit corrects that and additionally corrects some imprecise unit tests
that were not accounting for URL encoding.

Fixes issue #553.