### PR TITLE
Allows client to request case-insensitive sorting

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,7 @@ Not yet released.
 - :issue:`599`: fixes `unicode` bug using :func:`!urlparse.urljoin` with the
   `future`_ library in resource serialization.
 - :issue:`625`: adds schema metadata to root endpoint.
+- :issue:`626`: allows the client to request case-insensitive sorting.
 
 .. _future: http://python-future.org/
 

--- a/docs/sorting.rst
+++ b/docs/sorting.rst
@@ -4,7 +4,8 @@ Sorting
 Clients can sort according to the sorting protocol described in the `Sorting
 <http://jsonapi.org/format/#fetching-sorting>`__ section of the JSON API
 specification. Sorting by a nullable attribute will cause resources with null
-attributes to appear first.
+attributes to appear first. The client can request case-insensitive sorting by
+setting the query parameter ``ignorecase=1``.
 
 Clients can also request grouping by using the ``group`` query parameter. For
 example, if your database has two people with name ``'foo'`` and two people

--- a/flask_restless/views/base.py
+++ b/flask_restless/views/base.py
@@ -111,6 +111,9 @@ SINGLE_PARAM = 'filter[single]'
 #: request.
 SORT_PARAM = 'sort'
 
+#: The query parameter key that indicates whether sorting is case-insensitive.
+IGNORECASE_PARAM = 'ignorecase'
+
 #: The query parameter key that identifies grouping fields in a
 #: :http:method:`get` request.
 GROUP_PARAM = 'group'
@@ -1205,6 +1208,7 @@ class ModelView(MethodView):
                     for value in sort.split(',')]
         else:
             sort = []
+        ignorecase = bool(int(request.args.get(IGNORECASE_PARAM, '0')))
 
         # Determine grouping options.
         group_by = request.args.get(GROUP_PARAM)
@@ -1219,7 +1223,7 @@ class ModelView(MethodView):
         except ValueError:
             raise SingleKeyError('failed to extract Boolean from parameter')
 
-        return filters, sort, group_by, single
+        return filters, sort, group_by, single, ignorecase
 
 
 class APIBase(ModelView):
@@ -1601,7 +1605,7 @@ class APIBase(ModelView):
 
     def _get_collection_helper(self, resource=None, relation_name=None,
                                filters=None, sort=None, group_by=None,
-                               single=False):
+                               ignorecase=False, single=False):
         if (resource is None) ^ (relation_name is None):
             raise ValueError('resource and relation must be both None or both'
                              ' not None')
@@ -1614,7 +1618,7 @@ class APIBase(ModelView):
             search_ = partial(search, self.session, self.model)
         try:
             search_items = search_(filters=filters, sort=sort,
-                                   group_by=group_by)
+                                   group_by=group_by, ignorecase=ignorecase)
         except (FilterParsingError, FilterCreationError) as exception:
             detail = 'invalid filter object: {0}'.format(str(exception))
             return error_response(400, cause=exception, detail=detail)

--- a/flask_restless/views/function.py
+++ b/flask_restless/views/function.py
@@ -124,7 +124,8 @@ class FunctionAPI(ModelView):
 
         # Get the filtering, sorting, and grouping parameters.
         try:
-            filters, sort, group_by, single = self.collection_parameters()
+            filters, sort, group_by, single, ignorecase = \
+                self.collection_parameters()
         except (TypeError, ValueError, OverflowError) as exception:
             detail = 'Unable to decode filter objects as JSON list'
             return error_response(400, cause=exception, detail=detail)

--- a/flask_restless/views/relationships.py
+++ b/flask_restless/views/relationships.py
@@ -95,7 +95,7 @@ class RelationshipAPI(APIBase):
             return error_response(404, detail=detail)
         if is_like_list(primary_resource, relation_name):
             try:
-                filters, sort, group_by, single = \
+                filters, sort, group_by, single, ignorecase = \
                     self.collection_parameters(resource_id=resource_id,
                                                relation_name=relation_name)
             except (TypeError, ValueError, OverflowError) as exception:

--- a/flask_restless/views/resources.py
+++ b/flask_restless/views/resources.py
@@ -226,7 +226,7 @@ class API(APIBase):
 
         """
         try:
-            filters, sort, group_by, single = \
+            filters, sort, group_by, single, ignorecase = \
                 self.collection_parameters(resource_id=resource_id,
                                            relation_name=relation_name)
         except (TypeError, ValueError, OverflowError) as exception:
@@ -283,6 +283,7 @@ class API(APIBase):
                                                relation_name=relation_name,
                                                filters=filters, sort=sort,
                                                group_by=group_by,
+                                               ignorecase=ignorecase,
                                                single=single)
         else:
             resource = getattr(primary_resource, relation_name)
@@ -353,7 +354,8 @@ class API(APIBase):
 
         """
         try:
-            filters, sort, group_by, single = self.collection_parameters()
+            filters, sort, group_by, single, ignorecase = \
+                self.collection_parameters()
         except (TypeError, ValueError, OverflowError) as exception:
             detail = 'Unable to decode filter objects as JSON list'
             return error_response(400, cause=exception, detail=detail)
@@ -366,7 +368,8 @@ class API(APIBase):
                          single=single)
 
         return self._get_collection_helper(filters=filters, sort=sort,
-                                           group_by=group_by, single=single)
+                                           group_by=group_by, single=single,
+                                           ignorecase=ignorecase)
 
     def get(self, resource_id, relation_name, related_resource_id):
         """Returns the JSON document representing a resource or a collection of

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -399,6 +399,25 @@ class TestFetchCollection(ManagerTestBase):
         self.assertEqual(person2['id'], u'1')
         self.assertEqual(person2['attributes']['name'], u'B')
 
+    def test_case_insensitive_sorting_relationship_attributes(self):
+        """Test for case-insensitive sorting on relationship attributes."""
+        person1 = self.Person(id=1, name=u'B')
+        person2 = self.Person(id=2, name=u'a')
+        article1 = self.Article(id=1, author=person1)
+        article2 = self.Article(id=2, author=person2)
+        self.session.add_all([article1, article2, person1, person2])
+        self.session.commit()
+        query_string = {'sort': 'author.name', 'ignorecase': 1}
+        response = self.app.get('/api/article', query_string=query_string)
+        # The ASCII character code for the uppercase letter 'B' comes
+        # before the ASCII character code for the lowercase letter 'a',
+        # but in case-insensitive sorting, the 'a' should precede the
+        # 'B'.
+        document = loads(response.data)
+        article1, article2 = document['data']
+        self.assertEqual(article1['id'], u'2')
+        self.assertEqual(article2['id'], u'1')
+
 
 class TestFetchResource(ManagerTestBase):
 

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -376,6 +376,29 @@ class TestFetchCollection(ManagerTestBase):
         articles = document['data']
         self.assertEqual(['1', '2'], list(map(itemgetter('id'), articles)))
 
+    def test_case_insensitive_sorting(self):
+        """Test for case-insensitive sorting.
+
+        For more information, see GitHub issue #626.
+
+        """
+        person1 = self.Person(id=1, name=u'B')
+        person2 = self.Person(id=2, name=u'a')
+        self.session.add_all([person1, person2])
+        self.session.commit()
+        query_string = {'sort': 'name', 'ignorecase': 1}
+        response = self.app.get('/api/person', query_string=query_string)
+        # The ASCII character code for the uppercase letter 'B' comes
+        # before the ASCII character code for the lowercase letter 'a',
+        # but in case-insensitive sorting, the 'a' should precede the
+        # 'B'.
+        document = loads(response.data)
+        person1, person2 = document['data']
+        self.assertEqual(person1['id'], u'2')
+        self.assertEqual(person1['attributes']['name'], u'a')
+        self.assertEqual(person2['id'], u'1')
+        self.assertEqual(person2['attributes']['name'], u'B')
+
 
 class TestFetchResource(ManagerTestBase):
 


### PR DESCRIPTION
Partial fix for issue #626. This pull request allows the client to request case-insensitive sorting by setting the query parameter `ignorecase=1`. It does not create a server-side option to enable case-insensitive sorting by default. I plan on adding that in a new commit on this pull request.