### PR TITLE
Fetch all objects to include in one query to improve performance

### DIFF
--- a/flask_restless/views/base.py
+++ b/flask_restless/views/base.py
@@ -1413,7 +1413,7 @@ class APIBase(ModelView):
         # one instance. Otherwise, collect the resources to include for
         # each instance in `instances`.
         if isinstance(instance_or_instances, Query):
-            instances = instance_or_instances
+            instances = instance_or_instances.all()
             to_include = set(chain(map(self.resources_to_include, instances)))
         else:
             instance = instance_or_instances


### PR DESCRIPTION
Using an include results in fetching every object individually, even when this is not necessary. This commit evaluates the given query and uses the resulting objects instead. If your data model is properly configured, the important objects will already be fetched in this query. This improves some of our endpoint time from > 1 minute to 1 second.